### PR TITLE
Card display and pagination

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -140,11 +140,3 @@
   line-height: 1.2
 }
 
-/* Keep AdSense enabled globally, but never inject ads into card grids. */
-#items .google-auto-placed,
-#items ins.adsbygoogle,
-#items .adsbygoogle {
-    display: none !important;
-    max-height: 0 !important;
-    overflow: hidden !important;
-}

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -139,3 +139,12 @@
   padding: 1rem;
   line-height: 1.2
 }
+
+/* Keep AdSense enabled globally, but never inject ads into card grids. */
+#items .google-auto-placed,
+#items ins.adsbygoogle,
+#items .adsbygoogle {
+    display: none !important;
+    max-height: 0 !important;
+    overflow: hidden !important;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -126,7 +126,7 @@ const cards = [
     </header>
 
     <main class="container mx-auto px-4 py-8">
-        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
+        <div id="items" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
             {cards.map((card, index) => (
                 <Card
                     card={card}


### PR DESCRIPTION
Block auto-inserted ads within card grids while keeping global AdSense enabled.

This PR addresses the issue where AdSense auto-ads were appearing within card grids on mobile, despite per-card ad logic being removed. It adds CSS to hide auto-placed ad elements specifically within `#items` containers, and applies this ID to the homepage card grid.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e934ba38-0af1-46f0-9407-3852d17769a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e934ba38-0af1-46f0-9407-3852d17769a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

