### PR TITLE
Fix typo in README from 'untils' to 'utils'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Inside of the project, you'll see the following folders and files:
 │   │   └── 
 │   └── pages/
 │       └── 
-│   └── untils/
+│   └── utils/
 └── package.json
 ```
 


### PR DESCRIPTION
### Summary
Fixes a minor spelling error in the README.

### Changes
- Replaced “untils” to “utils” in the README. 

No functional changes.