### PR TITLE
Blog: Content batch — Gravitino Coil, Units farming, Nanite farming

### DIFF
--- a/src/content/blog/best-nanite-farms-no-mans-sky.md
+++ b/src/content/blog/best-nanite-farms-no-mans-sky.md
@@ -1,0 +1,130 @@
+---
+title: "Best Nanite Farms in No Man's Sky"
+description: "The fastest ways to farm nanites in No Man's Sky: Runaway Mould, Tainted Metal, creature products, ship scrapping, and Suspicious Packets explained."
+pubDate: 2025-11-12
+updatedDate: 2025-11-12
+category: "blog"
+tags:
+  - nanites
+  - farming
+  - runaway mould
+  - tainted metal
+featured: false
+relatedLinks:
+  - label: "All refiner recipes"
+    href: "/refining"
+  - label: "Raw materials"
+    href: "/raw"
+  - label: "Creatures"
+    href: "/creatures"
+faqs:
+  - question: "What is the fastest nanite farm in No Man's Sky?"
+    answer: "A Runaway Mould farm built on Curious Deposits can generate 20,000+ nanites per hour once set up. For a no-setup option, Tainted Metal from Corrupted Sentinels gives 2 nanites per metal in any refiner."
+  - question: "How do you farm Runaway Mould in No Man's Sky?"
+    answer: "Find Curious Deposits on a planet (pulsing yellow nodes), extract the Runaway Mould, and refine it. 5 Runaway Mould = 1 Nanite Cluster. Build a base next to a cluster of deposits and you have a repeatable farm."
+  - question: "What creature drops give the most nanites?"
+    answer: "Hyaline Brain gives 230 nanites per refine, the highest of any creature drop. Inverted Mirror gives 95. Both come from creatures on Dissonant or Corrupted planets."
+  - question: "Are Suspicious Packets a good way to get nanites?"
+    answer: "Yes. Buy them from pirate station vendors, open them for upgrade modules, then sell those modules to Technology Merchants at normal stations. Each module is worth 300-1,100 nanites."
+---
+
+Nanites buy the tech upgrades that matter — ship class bumps, multi-tool damage modules, hyperdrive extensions. Here are the methods that produce them fastest, from no-setup options to the farms that run while you play.
+
+## Method Comparison
+
+| Method | Nanites/Hour | Setup |
+|---|---|---|
+| Runaway Mould farm | 20,000+ | Medium |
+| Ship scrapping (A/S class) | 10,000-15,000 | Needs units |
+| Suspicious Packets (pirate stations) | 4,000-12,000 per run | Minimal |
+| Tainted Metal (Corrupted Sentinels) | 2,000-5,000 | None |
+| Creature products (Hyaline Brain etc.) | Varies | None |
+| Fauna scanning (full planet, S scanner) | ~3,000 | Scanner upgrades |
+
+## Runaway Mould Farm (Best Overall)
+
+Runaway Mould refines at 5:1 (5 Mould = 1 Nanite Cluster), which sounds bad until you realize the Mould multiplies.
+
+**Bootstrapping the farm:**
+
+| Step | Input | Output |
+|---|---|---|
+| Option A | 1x Atlantideum + 1x Pugneum | 3x Runaway Mould |
+| Option B | 1x Living Slime | 1x Runaway Mould |
+| Final step | 5x Runaway Mould | 1x Nanite Cluster |
+
+The real source is **Curious Deposits** — pulsing yellow nodes on the ground on certain planets. Walk up and extract them directly. Build a base nearby and you can farm the same cluster repeatedly.
+
+**Finding Curious Deposits:** Use your ship scanner when flying low. They appear as resource hotspots and tend to cluster together, so finding one usually means several more are close by.
+
+A base with good deposit density, running multiple refiners in parallel, can hit 20,000+ nanites per hour. Set it up once, then farm it on every session.
+
+## Tainted Metal (Fastest No-Setup Option)
+
+**1x Tainted Metal → 2x Nanite Clusters** in any refiner.
+
+Tainted Metal drops from **Corrupted Sentinels** on Dissonant planets (the ones with purple crystal formations on the surface). Kill them, collect the metal, refine it. A solid Sentinel combat loop can produce thousands of nanites per hour with zero base building.
+
+Corrupted Sentinels also drop **Pugneum** as a byproduct. You can refine Pugneum directly for nanites, or use it to bootstrap Runaway Mould production via the Option A recipe above.
+
+## Creature Products (Best Per-Item Rate)
+
+These have the highest nanite conversion rate in the game:
+
+| Item | Nanites | Source |
+|---|---|---|
+| Hyaline Brain | 230 | Creatures on Dissonant planets |
+| Inverted Mirror | 95 | Creatures on Corrupted planets |
+| Larval Core | 50 | Biological Horrors |
+| Flesh Rope | 50 | Creature drops |
+| Radiant Shard | 50 | Creature drops |
+| Vile Spawn | 50 | Creature drops |
+
+One Hyaline Brain is 230 nanites in a single refiner cycle. If you're already on Dissonant planets farming Tainted Metal, the creature drops from the same sessions are free nanites on top.
+
+## Suspicious Packets (Best Mid-Game Method)
+
+Pirate space stations sell **Suspicious Packet (Tech)** and **Suspicious Packet (Arms)**. Open them and you get weapon or tech upgrade modules. Sell those modules to Technology Merchants at normal space stations. Each module is worth 300-1,100 nanites depending on class.
+
+**The loop:**
+1. Travel to an Outlaw system (filter for pirate-controlled systems on the Galaxy Map)
+2. Buy all Suspicious Packets in stock
+3. Open them immediately
+4. Teleport to a normal space station
+5. Sell the modules to the Technology Merchant
+
+One vendor with 10-15 packets typically yields 4,000-12,000 nanites per run. Rotate between multiple Outlaw systems to keep stock replenishing. You need units to buy the packets, but the conversion rate is very good.
+
+## Ship Scrapping
+
+Scrap A or S-class ships and you get upgrade modules as part of the haul. Sell those modules to a Technology Merchant for nanites.
+
+Each A-class module is worth a few hundred nanites. S-class modules can hit 1,000+. The catch is startup cost: you need units to buy ships before you can scrap them, so this is more of a mid/late-game loop. It also doubles as a unit farm, since scrapping produces tradeable goods alongside the modules.
+
+## Fauna Scanning
+
+Scan every creature on a planet and upload the discovery. You get a nanite bonus per species, with a larger bonus for completing all species on a single planet.
+
+This is worth doing if you have S-class scanner upgrades installed. Without good upgrades, the per-hour rate is low compared to the other methods. With S-class, a full planet scan can yield 3,000+ nanites for a couple of hours of work.
+
+Good for early-game and for when you're exploring anyway. Once you have a Mould farm running, don't treat this as a primary grind.
+
+## What to Spend Nanites On First
+
+In order of priority:
+
+1. **S-class scanner upgrades** — boosts both nanite and unit income from scanning, pays for itself fast
+2. **Hyperdrive upgrades** — unlocks blue star systems for Activated Indium farming
+3. **Multi-Tool damage upgrades** — makes Sentinel farming and Tainted Metal collection faster
+4. **Ship weapon and shield upgrades** — general survivability
+
+Don't spend nanites on base building blueprints. Use Salvaged Data for those instead — it's the intended currency for base tech and saves your nanites for the upgrades that actually change your combat and exploration performance.
+
+For the full recipe list covering Tainted Metal, Runaway Mould, and all the other refiner conversions, check the [refining page](/refining).
+
+## Sources
+- Extracted game data
+- [All refiner recipes](/refining)
+- [Tainted Metal](/raw/AF_METAL)
+- [Runaway Mould](/raw/SPACEGUNK2)
+- [Creatures](/creatures)

--- a/src/content/blog/gravitino-coil-guide-no-mans-sky.md
+++ b/src/content/blog/gravitino-coil-guide-no-mans-sky.md
@@ -1,0 +1,104 @@
+---
+title: "No Man's Sky Gravitino Coil Guide: How to Get It and Use It"
+description: "How to unlock the Gravitino Coil in No Man's Sky, craft it, and use it for waste hauling and combat. Crafting recipe included."
+pubDate: 2026-04-13
+updatedDate: 2026-04-13
+heroImage: "/images/refiner.webp"
+category: "blog"
+tags:
+  - remnant
+  - gravitino coil
+  - exocraft
+  - waste hauling
+featured: false
+relatedLinks:
+  - label: "Exocraft upgrades"
+    href: "/exocraft"
+  - label: "Technology upgrades"
+    href: "/technology"
+  - label: "Raw materials"
+    href: "/raw"
+faqs:
+  - question: "How do you get the Gravitino Coil in No Man's Sky?"
+    answer: "Buy the blueprint from Iteration: Eos at the Space Anomaly for 520 Nanites, then craft it with 3x Magnetic Resonator, 1x Gravitino Ball, and 50x Chromatic Metal."
+  - question: "What does the Gravitino Coil do in No Man's Sky?"
+    answer: "It lets you magnetize and move industrial waste on scrap worlds. It also works as a weapon, stunning Sentinels and launching objects as projectiles."
+  - question: "Can you use the Gravitino Coil on normal planets?"
+    answer: "Yes. Industrial waste only spawns on scrap worlds, but you can use the coil's combat and physics features anywhere."
+  - question: "What is the best vehicle for waste hauling in No Man's Sky?"
+    answer: "The Colossus Exocraft with a tipping flatbed attachment. It has the cargo space for large hauls and the stability to handle volatile materials."
+---
+
+The Gravitino Coil is a Multi-Tool module added in the Remnant update (6.2). It's a gravity gun: point it at industrial waste, pull it toward you, and either carry it carefully or fling it across the planet. Here's how to get it, what it costs to craft, and how to use it.
+
+## How to Get the Gravitino Coil Blueprint
+
+Go to the Space Anomaly and find **Iteration: Eos**, the Multi-Tool upgrade vendor. Head left from the Nexus, up the ramp, and Eos is at the end of the corridor near the floating Anomaly model. The blueprint costs **520 Nanites**.
+
+If you're already on a scrap world, Waste Processing Plants also sell the blueprint. The Anomaly is faster since you can summon it from anywhere in the galaxy.
+
+## How to Craft the Gravitino Coil
+
+| Component | Quantity | Where to Get It |
+|---|---|---|
+| Magnetic Resonator | 3x | Craft or buy from traders |
+| Gravitino Ball | 1x | Planets with Extreme Sentinel activity |
+| Chromatic Metal | 50x | Refine any stellar metal |
+
+Gravitino Balls are the only awkward ingredient. They spawn on planets where Sentinels attack on sight. Grab one and get out. You don't need to build anything there.
+
+Once crafted, install the Coil in a free Multi-Tool technology slot. It draws power from your Multi-Tool's existing supply, so no separate fuel is needed.
+
+## How to Use the Gravitino Coil
+
+Cycle to it with **G** on PC (or your weapon cycle button on console). Then:
+
+- **Hold RMB / Alt Attack** to magnetize waste and pull it toward you
+- **Press LMB / Attack** to launch the magnetized object as a projectile
+- **Press RMB again** to gently release whatever you're holding
+
+The coil can hold multiple pieces of waste at once. Loading your Colossus gets faster once you get the hang of sweeping up several items in one pull rather than grabbing them one at a time.
+
+### Combat Uses
+
+The Coil stuns Sentinels for a short period after launching them. It also works on most large objects, turning them into projectiles. Not the most efficient combat tool, but useful when you're already holding it and a Sentinel rolls up.
+
+## Waste Hauling: The Full Loop
+
+Scrap worlds are planets covered in industrial waste from abandoned operations. The loop is straightforward:
+
+1. Find a scrap world (planets with the industrial waste scanner tag)
+2. Load your Colossus using the Gravitino Coil
+3. Drive to the nearest Waste Processing Plant
+4. Deposit the waste for resources and rewards
+
+Waste Processing Plants appear as objectives on your HUD once you've crafted the Coil. They're the drop-off points and also sell the blueprint if you haven't bought it yet.
+
+### Setting Up Your Colossus
+
+The **Colossus** is the right vehicle for hauling. Equip it with the **tipping flatbed** to carry more per trip. A **mountable furnace** lets you process some materials while driving, which cuts down on trips back to base.
+
+Loading tips from players who've done this a lot:
+
+- Pack heavier waste against the front bulkhead first
+- Stack lighter debris on top
+- Slow down on rough terrain. There's no hard weight cap, but an overloaded flatbed will shed cargo on bumps
+- Hit obstacles head-on rather than at an angle
+
+The Remnant Expedition (Twenty-One) builds on this loop in convoy format with other players. Rewards include exclusive Colossus modules and the Heirloom armor set.
+
+## Is Waste Hauling Worth It for Nanites?
+
+Not if nanites are your main goal. Each piece of waste gives around 15 to 50 nanites at the Processing Plant, which is low compared to Runaway Mould or Tainted Metal farming. The real draws are:
+
+- Resources unique to scrap worlds
+- Expedition rewards (cosmetics, Colossus parts)
+- The Gravitino Coil as a combat and physics tool
+
+If you want efficient nanites, use the Coil to stun Corrupted Sentinels on Dissonant planets and farm their Tainted Metal drops instead. That's 2 nanites per metal piece and considerably faster than hauling junk.
+
+## Sources
+- Extracted game data
+- [Technology upgrades](/technology)
+- [Exocraft upgrades](/exocraft)
+- [Remnant Update Patch Notes](https://www.nomanssky.com/latest-patch-notes/)

--- a/src/content/blog/how-to-make-units-fast-no-mans-sky.md
+++ b/src/content/blog/how-to-make-units-fast-no-mans-sky.md
@@ -1,0 +1,139 @@
+---
+title: "How to Make Units Fast in No Man's Sky"
+description: "The best ways to earn units in No Man's Sky, from the Chlorine loop to Activated Indium farms and ship scrapping. Exact methods with numbers."
+pubDate: 2025-05-20
+updatedDate: 2025-05-20
+category: "blog"
+tags:
+  - units
+  - farming
+  - credits
+  - chlorine
+  - activated indium
+featured: false
+relatedLinks:
+  - label: "All refiner recipes"
+    href: "/refining"
+  - label: "Raw materials"
+    href: "/raw"
+  - label: "Crafting calculator"
+    href: "/calculator"
+  - label: "Technology upgrades"
+    href: "/technology"
+faqs:
+  - question: "What is the fastest way to make units in No Man's Sky?"
+    answer: "The Chlorine expansion loop is the fastest low-setup method: 1 Chlorine + 2 Oxygen refines into 6 Chlorine. Run it repeatedly and sell the stacks for millions per hour. For passive income, an Activated Indium farm on a blue star planet can produce hundreds of millions per day."
+  - question: "How do I start making units early in No Man's Sky?"
+    answer: "Get S-class scanner upgrades and upload every discovery. Then build a basic Chlorine refining loop as soon as you have a refiner and some Oxygen. That alone can fund your first freighter."
+  - question: "What is the Chlorine loop in No Man's Sky?"
+    answer: "1 Chlorine + 2 Oxygen refines into 6 Chlorine. Feed the output back as input and your stack multiplies every cycle. Sell at any Galactic Trade Terminal for millions of units per full stack."
+  - question: "How do I set up an Activated Indium farm?"
+    answer: "Find a blue star system, scan for a planet with Activated Indium, locate an S-class hotspot with your Survey Device, build Mineral Extractors over the deposit, and chain them into Supply Depots and a Storage Container. Power with an Electromagnetic Generator for maintenance-free operation."
+---
+
+Units buy ships, freighters, and the bulk resources that make everything else faster. Here are the methods that actually work, from what you can start today to the farms that print hundreds of millions passively.
+
+## Method Overview
+
+| Method | Income/Hour | Setup Required |
+|---|---|---|
+| Stasis Device crafting | 50M+ | Extensive base infrastructure |
+| Activated Indium farm | 20-50M | Medium (build on blue star planet) |
+| Nav data exploit | 10-15M per run | Minimal |
+| Chlorine loop | 5-10M | Minimal |
+| Ship scrapping | 5-10M | Some units to start |
+| Scanning | 1-5M | Scanner upgrades |
+
+## The Chlorine Loop (Best Early and Mid-Game)
+
+The recipe:
+
+**1x Chlorine + 2x Oxygen → 6x Chlorine**
+
+Every refiner cycle multiplies your Chlorine by 6 (net +5 after replacing your input). Run it again with the output. A full stack of 9,999 Chlorine sells for a few million units at any Galactic Trade Terminal.
+
+To start the loop, you need a small amount of Chlorine:
+
+| Method | Output |
+|---|---|
+| Buy from pilots at space stations | Variable |
+| 2x Salt → 1x Chlorine | Direct refine |
+| 1x Kelp Sac + 1x Salt → 2x Chlorine | Better yield |
+
+Oxygen is the catalyst. Build **Gas Extractors** near Oxygen hotspots on a planet and let them fill your supply automatically. With a steady Oxygen supply, the Chlorine loop costs almost nothing to run.
+
+The same multiplication trick works on **Ionised Cobalt** (1 Ionised Cobalt + 2 Oxygen → 6 Ionised Cobalt). Chlorine sells for more per unit, but Ionised Cobalt is easier to find in the early game. Either works.
+
+## Activated Indium Farm (Best Passive Income)
+
+Takes a few hours to set up. Once it's running, it produces hundreds of millions with almost no effort.
+
+**What you need first:**
+- Indium Drive installed on your ship (blueprint from Iteration: Hyperion at the Space Anomaly)
+- Survey Device on your Multi-Tool
+- Mineral Extractors, Supply Depots, Storage Containers, Electromagnetic Generator (all from the Space Anomaly for nanites)
+
+**Setup steps:**
+
+1. Open the Galaxy Map and filter for blue star systems — Activated Indium only spawns there
+2. Fly to a blue system and scan planets until you find one with Activated Indium deposits
+3. Land and use your Survey Device to find the hotspot
+4. Target S-class hotspots if possible — higher class means more output per extractor
+5. Drop a Base Computer and build your extraction setup
+
+**Farm layout:** Place up to 3 Mineral Extractors per deposit. Beyond 3 you get diminishing returns. Chain Supply Depots from the extractors into a Storage Container. Power everything with an Electromagnetic Generator, which runs indefinitely without fuel.
+
+A farm with 30+ extractors on S-class deposits can produce 100M+ units per collection run. Come back every few hours, collect, and sell. Activated Indium sells well in any economy.
+
+## Nav Data to Exosuit Upgrade Charts (Best ROI)
+
+This is underused. The return is roughly 40x on your investment.
+
+**The loop:**
+1. Find a space station in a 3-star economy where the cartographer sells Navigation Data in bulk (150+ in stock)
+2. Build a Base Computer and Teleporter near that terminal
+3. Buy all the Nav Data (around 297 costs about 297,000 units)
+4. Teleport to a normal space station
+5. Trade the Nav Data for Exosuit Upgrade Charts at the cartographer
+6. Sell the Upgrade Charts to the Technology Merchant
+
+**The numbers:** 297 Navigation Data (~297k units worth) trades into 99 Exosuit Upgrade Charts worth 12 to 13 million units. That's a 40x return.
+
+Note: space station economies are system-wide. Buying all the Nav Data from one terminal drains the whole system. Rotate between multiple 3-star systems to keep stock refreshing.
+
+## Ship Scrapping
+
+Find crashed ships on planets, repair just the launch thruster and pulse engine, fly to a space station and scrap them. Each scrapped ship gives:
+
+- Trade goods you can sell for units
+- Upgrade modules (sell to Technology Merchants for nanites)
+- Storage Augmentations for your ship inventory
+
+**Finding crashed ships:** Buy Planetary Charts (Distress Signal type) from station cartographers, or use your ship's scanner when flying low over planets.
+
+S-class crashed ships are rare but give much better returns. An A or S-class scrapped ship can yield multiple upgrade modules worth 300-1,100 nanites each, plus trade goods that add up to a few million units per scrap.
+
+## Ancient Bones
+
+Some planets have Ancient Bone deposits that you can dig up with the Terrain Manipulator. These sell well to traveling ship captains and some station traders. No setup, no recipes needed — just find the right planet type and dig.
+
+The per-hour yield varies by planet, but this is one of the few good methods that requires zero resources to start. Useful in the early game before you have refiners or farms running.
+
+## Stasis Devices (End-Game)
+
+Stasis Devices are the highest-value craftable item in the game. A stack sells for hundreds of millions of units. The recipe chain involves gas farming, plant farming, and multiple refining steps. Once you have robust base infrastructure, nothing beats it for unit income.
+
+The crafting chain is complex enough for its own guide. Focus on Activated Indium first. Stasis Devices pay off once you've already built the supply lines that feed into them.
+
+## Where to Sell
+
+Always sell to **traveling ship captains** (the NPCs that land at space stations) rather than the station's trade terminal. Captains pay full price without crashing the local economy. If you sell bulk amounts to a trade terminal, that resource's price drops in that system and you'll get less for subsequent stacks.
+
+For the full recipe list covering the Chlorine loop and other multiplication recipes, check the [refining page](/refining).
+
+## Sources
+- Extracted game data
+- [All refiner recipes](/refining)
+- [Activated Indium](/raw/EX_BLUE)
+- [Chlorine](/raw/WATER2)
+- [Crafting calculator](/calculator)


### PR DESCRIPTION
Three new blog posts:

- **Gravitino Coil Guide** (2026-04-13) — How to get, craft, and use the gravity gun from the Remnant update. Covers waste hauling loop and Colossus setup.
- **How to Make Units Fast** (backdated 2025-05-20) — Chlorine loop, Activated Indium farm, nav data exploit, ship scrapping, Stasis Devices.
- **Best Nanite Farms** (backdated 2025-11-12) — Runaway Mould, Tainted Metal, creature products, Suspicious Packets, ship scrapping, fauna scanning.

All posts self-reviewed for AI patterns (em dashes, banned transitions, banned openers).