### PR TITLE
Blog: Crafting guides — Fusion Ignitor, Stasis Device, comparison

### DIFF
--- a/src/content/blog/fusion-ignitor-vs-stasis-device-no-mans-sky.md
+++ b/src/content/blog/fusion-ignitor-vs-stasis-device-no-mans-sky.md
@@ -1,0 +1,118 @@
+---
+title: "Fusion Ignitor vs Stasis Device: Which Is Easier to Craft in No Man's Sky?"
+description: "Both sell for 15.6M units. But Fusion Ignitor and Stasis Device have different recipe chains — one needs toxic planets, the other needs better farms. Here's the breakdown."
+pubDate: 2025-07-15
+updatedDate: 2025-07-15
+category: "blog"
+tags:
+  - crafting
+  - fusion ignitor
+  - stasis device
+  - units
+  - farming
+featured: false
+relatedLinks:
+  - label: "Browse craftable products"
+    href: "/products"
+  - label: "Crafting calculator"
+    href: "/calculator"
+  - label: "All refiner recipes"
+    href: "/refining"
+faqs:
+  - question: "Is the Fusion Ignitor or Stasis Device easier to craft?"
+    answer: "Stasis Device is easier for most players. Its hardest farm ingredient is Gamma Root (400x), which grows in standard Biodomes. The Fusion Ignitor's hardest ingredient is Fungal Mould (600x), which is rarer and harder to farm at volume, plus it needs Ammonia and Uranium from toxic and radioactive planets."
+  - question: "Do the Fusion Ignitor and Stasis Device sell for the same price?"
+    answer: "Yes. Both have a base value of 15,600,000 units."
+  - question: "What ingredients do the Fusion Ignitor and Stasis Device share?"
+    answer: "Both require a Quantum Processor (Circuit Board + Superconductor), the same gas inputs (Sulphurine, Radon, Nitrogen), and the same plant crops (Cactus Flesh, Star Bulb, Solanium, Frost Crystal)."
+  - question: "Can I sell both at the same time?"
+    answer: "Yes. If you build farms for both, many ingredients overlap. Running both crafting chains at once is more efficient than running either one alone."
+---
+
+Both items sell for 15,600,000 units. Both have long recipe chains. The question is which one is easier to build given what you already have. The short answer: **Stasis Device** for most players, but it depends on your farms.
+
+## Side-by-Side Recipe Breakdown
+
+| | Fusion Ignitor | Stasis Device |
+|---|---|---|
+| Base value | 15,600,000 units | 15,600,000 units |
+| Shared component | Quantum Processor | Quantum Processor |
+| Unique component | Portable Reactor | Cryogenic Chamber |
+| Unique alloy | Geodesite | Iridesite |
+| Hardest farm ingredient | Fungal Mould (600x) | Gamma Root (400x) |
+| Hardest mineral | Ammonia + Uranium | Phosphorus (easy) |
+| Gas requirements | Sulphurine, Radon, Nitrogen | Sulphurine, Radon, Nitrogen |
+
+## What They Share
+
+Both require a **Quantum Processor** — the most complex intermediate component in either chain. It takes:
+
+- 1x Circuit Board (100x Frost Crystal + 200x Solanium + 100x Cactus Flesh + 200x Star Bulb)
+- 1x Superconductor (250x Sulphurine + 250x Radon + 250x Nitrogen + 150x Condensed Carbon)
+
+Both also consume the same three gases (Sulphurine, Radon, Nitrogen), so your gas extractor setup serves both crafting chains. Build it once, use it for either item.
+
+## Where They Diverge
+
+### Fusion Ignitor: The Portable Reactor Chain
+
+The Portable Reactor needs Liquid Explosive and Fusion Accelerant.
+
+Liquid Explosive needs:
+- **Acid:** 25x Mordite + 600x Fungal Mould
+- **Unstable Gel:** 200x Cactus Flesh
+
+**600x Fungal Mould is the problem.** It grows on swamp and toxic planets, or in Biodomes with swamp conditions. It's not impossible, but it's a dedicated farm commitment at that volume. No other high-value craft needs it, so you're building a Fungal Mould farm just for this.
+
+The **Geodesite** alloy also needs Ammonia (toxic planet) and Uranium (radioactive planet). If you don't have quick access to both planet types, you're making extra supply runs.
+
+### Stasis Device: The Cryogenic Chamber Chain
+
+The Cryogenic Chamber needs Living Glass and Cryo-pump.
+
+Living Glass needs:
+- **Lubricant:** 50x Faecium + 400x Gamma Root
+- **5x Glass:** 200x Frost Crystal total
+
+Gamma Root at 400x is the main farm here. It grows on irradiated planets or in Biodomes. Most established players already have it if they've run the NPC mission chains. Faecium is easy — creatures drop it almost everywhere, and you only need 50x.
+
+The **Iridesite** alloy needs Paraffinium, Phosphorus, and Dioxite — from lush, fiery, and frozen planets. All three are common planet types and the quantities are modest (50x each).
+
+## The Verdict
+
+**Stasis Device is easier for most players,** for two reasons:
+
+1. **Gamma Root is a simpler farm than Fungal Mould.** Both need Biodomes if you don't have the right native planet, but Gamma Root has no volume spike on the scale of 600x. The hardest single ingredient in the Stasis chain is 400x Gamma Root. The Fusion Ignitor asks for 600x Fungal Mould, which is rarer to come by.
+
+2. **Iridesite is easier to supply than Geodesite.** Paraffinium, Phosphorus, and Dioxite all appear on accessible, common planet types. Geodesite requires Ammonia and Uranium, which specifically need toxic and radioactive planets — a bit more specialized to stock up on.
+
+### When Fusion Ignitor Is Easier
+
+Fusion Ignitor wins if you already have:
+- A working Fungal Mould farm (e.g., from farming Acid for other recipes)
+- Easy access to toxic and radioactive planets in your home system
+- No established Gamma Root farm
+
+If both farms are zero and you're starting fresh, the Stasis Device chain gets you to a sellable item faster.
+
+## Running Both at Once
+
+Here's the practical approach: run both. The shared ingredients (Quantum Processor, all three gases, Cactus Flesh, Star Bulb, Solanium, Frost Crystal) mean your gas setup and most of your plant farm feeds both chains simultaneously. Add a Fungal Mould setup for the Portable Reactor and a Gamma Root farm for the Cryogenic Chamber, and one collection run produces materials for both items.
+
+That doubles your output per session for almost no extra infrastructure.
+
+| Farm | Feeds |
+|---|---|
+| Gas extractors (Sulphurine, Radon, Nitrogen) | Both |
+| Cactus Flesh + Star Bulb + Solanium + Frost Crystal | Both |
+| Fungal Mould + Mordite | Fusion Ignitor only |
+| Gamma Root + Faecium | Stasis Device only |
+| Pyrite, Ammonia, Uranium | Fusion Ignitor only |
+| Paraffinium, Phosphorus, Dioxite | Stasis Device only |
+
+For the full recipe trees, see the individual crafting guides for [Fusion Ignitor](/blog/how-to-craft-fusion-ignitor-no-mans-sky) and [Stasis Device](/blog/how-to-craft-stasis-device-no-mans-sky). The [crafting calculator](/calculator) can help you work out exactly how much of each base material you need per batch.
+
+## Sources
+- Extracted game data
+- [Craftable products](/products)
+- [Crafting calculator](/calculator)

--- a/src/content/blog/how-to-craft-fusion-ignitor-no-mans-sky.md
+++ b/src/content/blog/how-to-craft-fusion-ignitor-no-mans-sky.md
@@ -1,0 +1,150 @@
+---
+title: "How to Craft a Fusion Ignitor in No Man's Sky"
+description: "Full Fusion Ignitor crafting guide: every ingredient, every sub-recipe, and which farms you actually need. Sells for 15.6M units."
+pubDate: 2025-02-18
+updatedDate: 2025-02-18
+category: "blog"
+tags:
+  - crafting
+  - fusion ignitor
+  - units
+  - farming
+featured: false
+relatedLinks:
+  - label: "Browse craftable products"
+    href: "/products"
+  - label: "Crafting calculator"
+    href: "/calculator"
+  - label: "All refiner recipes"
+    href: "/refining"
+faqs:
+  - question: "What do I need to craft a Fusion Ignitor in No Man's Sky?"
+    answer: "A Fusion Ignitor requires 1x Portable Reactor, 1x Quantum Processor, and 1x Geodesite. Each of those has its own sub-recipe chain. The full build needs gas farming (Sulphurine, Radon, Nitrogen), plant farming (Fungal Mould, Cactus Flesh, Solanium, Star Bulb, Frost Crystal), and planet minerals (Pyrite, Ammonia, Uranium)."
+  - question: "How much does a Fusion Ignitor sell for?"
+    answer: "A Fusion Ignitor has a base value of 15,600,000 units."
+  - question: "Where do I get the Fusion Ignitor blueprint?"
+    answer: "From the Synthesis Lab on the Space Anomaly, or by raiding planetary Manufacturing Facilities."
+  - question: "What is Geodesite made from?"
+    answer: "Geodesite requires 1x Dirty Bronze (50 Pyrite + 100 Pure Ferrite), 1x Herox (50 Ammonia + 50 Ionised Cobalt), and 1x Lemmium (50 Uranium + 100 Pure Ferrite)."
+---
+
+The Fusion Ignitor sells for 15,600,000 units and is one of the highest-value craftable items in No Man's Sky. The recipe chain is long but manageable once you know what farms to build. Here's every ingredient, broken down to base materials.
+
+## The Full Recipe Tree
+
+**Fusion Ignitor** requires:
+- 1x Portable Reactor
+- 1x Quantum Processor
+- 1x Geodesite
+
+Each of those requires its own sub-components.
+
+### Portable Reactor
+
+| Ingredient | Requires |
+|---|---|
+| Liquid Explosive | 1x Acid + 1x Unstable Gel |
+| Fusion Accelerant | 1x Organic Catalyst + 1x Nitrogen Salt |
+
+**Breaking that down further:**
+
+| Component | Base Ingredients |
+|---|---|
+| Acid | 25x Mordite + 600x Fungal Mould |
+| Unstable Gel | 200x Cactus Flesh |
+| Organic Catalyst | 1x Thermic Condensate + 1x Enriched Carbon |
+| Nitrogen Salt | 250x Nitrogen + 50x Condensed Carbon |
+| Thermic Condensate | 250x Sulphurine + 50x Condensed Carbon |
+| Enriched Carbon | 250x Radon + 50x Condensed Carbon |
+
+### Quantum Processor
+
+| Ingredient | Requires |
+|---|---|
+| Circuit Board | 1x Heat Capacitor + 1x Poly Fibre |
+| Superconductor | 1x Semiconductor + 1x Enriched Carbon |
+
+**Breaking that down:**
+
+| Component | Base Ingredients |
+|---|---|
+| Heat Capacitor | 100x Frost Crystal + 200x Solanium |
+| Poly Fibre | 100x Cactus Flesh + 200x Star Bulb |
+| Semiconductor | 1x Thermic Condensate + 1x Nitrogen Salt |
+| Enriched Carbon | 250x Radon + 50x Condensed Carbon |
+
+### Geodesite
+
+| Alloy | Base Ingredients |
+|---|---|
+| Dirty Bronze | 50x Pyrite + 100x Pure Ferrite |
+| Herox | 50x Ammonia + 50x Ionised Cobalt |
+| Lemmium | 50x Uranium + 100x Pure Ferrite |
+
+## What You Actually Need to Farm
+
+Here's the full list of base materials for one Fusion Ignitor, grouped by source type:
+
+### Gas Extractor Farm
+| Gas | Approximate Total Needed |
+|---|---|
+| Sulphurine | 500x+ |
+| Radon | 500x+ |
+| Nitrogen | 500x+ |
+| Condensed Carbon | 300x+ |
+
+Run Gas Extractors on planets that produce Sulphurine (hot/volcanic), Radon (radioactive), and Nitrogen (frozen). You'll need all three. Power with Electromagnetic Generators to avoid fuel upkeep.
+
+### Plant Farm (Biodomes or Hydroponics)
+| Plant | Total Needed | Native Planet |
+|---|---|---|
+| Fungal Mould | 600x | Swamp/toxic |
+| Cactus Flesh | 300x | Desert |
+| Solanium | 200x | Fiery/toxic |
+| Star Bulb | 200x | Lush |
+| Frost Crystal | 100x | Frozen |
+| Mordite | 25x | Any planet (drops from creatures too) |
+
+Fungal Mould at 600x is the biggest bottleneck. It grows in swamp and toxic planet biomes, or in Biodomes with the right climate. If you don't have a swamp planet in your home system, Biodomes are the practical route.
+
+### Planet Mining
+| Material | Source |
+|---|---|
+| Pyrite | Desert/cave deposits |
+| Ammonia | Toxic planet surface |
+| Uranium | Radioactive planet surface |
+| Ionised Cobalt | Underground caves (most planets) |
+| Pure Ferrite | Surface rocks (refine Ferrite Dust) |
+
+Pyrite, Ammonia, and Uranium each appear on specific planet types. If your home system doesn't have all three biomes, you'll need to grab bulk stacks when visiting those systems during normal play.
+
+## Where to Get the Blueprint
+
+Two options:
+
+1. **Synthesis Lab on the Space Anomaly** — buy the Fusion Ignitor blueprint and all sub-component blueprints here for Nanites. This is the reliable route.
+2. **Planetary Manufacturing Facilities** — raid them until the blueprint drops. Faster if you get lucky, slow if you don't.
+
+You'll also need blueprints for the intermediates: Portable Reactor, Quantum Processor, Liquid Explosive, Fusion Accelerant, Geodesite, and the three alloys (Dirty Bronze, Herox, Lemmium). Get them all at the Synthesis Lab before you start.
+
+## Crafting Order
+
+Work from the bottom up:
+
+1. Set up gas extractors for Sulphurine, Radon, and Nitrogen
+2. Plant and harvest Fungal Mould, Cactus Flesh, Solanium, Star Bulb, Frost Crystal
+3. Mine Pyrite, Ammonia, Uranium, Ionised Cobalt, Pure Ferrite
+4. Craft the three alloys (Dirty Bronze, Herox, Lemmium) in a refiner to make Geodesite
+5. Craft Thermic Condensate, Enriched Carbon, Nitrogen Salt from gases
+6. Craft Organic Catalyst, Semiconductor, then Fusion Accelerant and Superconductor
+7. Craft Liquid Explosive and Circuit Board from farm products
+8. Combine into Portable Reactor and Quantum Processor
+9. Assemble Fusion Ignitor
+
+It looks like a lot of steps, but most of the work is just waiting for farms. Once gas extractors and plant farms are running, one collection cycle gives you enough to craft several Ignitors.
+
+## Sources
+- Extracted game data
+- [Craftable products](/products)
+- [Crafting calculator](/calculator)
+- [All refiner recipes](/refining)

--- a/src/content/blog/how-to-craft-stasis-device-no-mans-sky.md
+++ b/src/content/blog/how-to-craft-stasis-device-no-mans-sky.md
@@ -1,0 +1,149 @@
+---
+title: "How to Craft a Stasis Device in No Man's Sky"
+description: "Full Stasis Device crafting guide with every ingredient and sub-recipe. Sells for 15.6M units and shares components with the Fusion Ignitor."
+pubDate: 2025-04-22
+updatedDate: 2025-04-22
+category: "blog"
+tags:
+  - crafting
+  - stasis device
+  - units
+  - farming
+featured: false
+relatedLinks:
+  - label: "Browse craftable products"
+    href: "/products"
+  - label: "Crafting calculator"
+    href: "/calculator"
+  - label: "All refiner recipes"
+    href: "/refining"
+faqs:
+  - question: "What do I need to craft a Stasis Device in No Man's Sky?"
+    answer: "A Stasis Device requires 1x Quantum Processor, 1x Cryogenic Chamber, and 1x Iridesite. The full chain needs gas farming (Sulphurine, Radon, Nitrogen), plant farming (Gamma Root, Frost Crystal, Cactus Flesh, Star Bulb, Solanium), and alloy minerals (Paraffinium, Phosphorus, Dioxite, Ionised Cobalt)."
+  - question: "How much does a Stasis Device sell for?"
+    answer: "A Stasis Device has a base value of 15,600,000 units."
+  - question: "Where do I get the Stasis Device blueprint?"
+    answer: "From the Synthesis Lab on the Space Anomaly, or by raiding planetary Manufacturing Facilities."
+  - question: "What is Iridesite made from?"
+    answer: "Iridesite requires 1x Aronium (50 Paraffinium + 50 Ionised Cobalt), 1x Magno-gold (50 Phosphorus + 50 Ionised Cobalt), and 1x Grantine (50 Dioxite + 50 Ionised Cobalt)."
+---
+
+The Stasis Device sells for 15,600,000 units and shares one major component (the Quantum Processor) with the Fusion Ignitor. The rest of the chain leans on plant farms rather than toxic and radioactive planet minerals, which makes it the preferred build for players with established Biodomes. Here's every ingredient broken down to base materials.
+
+## The Full Recipe Tree
+
+**Stasis Device** requires:
+- 1x Quantum Processor
+- 1x Cryogenic Chamber
+- 1x Iridesite
+
+### Quantum Processor
+
+| Ingredient | Requires |
+|---|---|
+| Circuit Board | 1x Heat Capacitor + 1x Poly Fibre |
+| Superconductor | 1x Semiconductor + 1x Enriched Carbon |
+
+**Breaking that down:**
+
+| Component | Base Ingredients |
+|---|---|
+| Heat Capacitor | 100x Frost Crystal + 200x Solanium |
+| Poly Fibre | 100x Cactus Flesh + 200x Star Bulb |
+| Semiconductor | 1x Thermic Condensate + 1x Nitrogen Salt |
+| Thermic Condensate | 250x Sulphurine + 50x Condensed Carbon |
+| Nitrogen Salt | 250x Nitrogen + 50x Condensed Carbon |
+| Enriched Carbon | 250x Radon + 50x Condensed Carbon |
+
+### Cryogenic Chamber
+
+| Ingredient | Requires |
+|---|---|
+| Living Glass | 1x Lubricant + 5x Glass |
+| Cryo-pump | 1x HoT Ice + 1x Thermic Condensate |
+
+**Breaking that down:**
+
+| Component | Base Ingredients |
+|---|---|
+| Lubricant | 50x Faecium + 400x Gamma Root |
+| Glass | 40x Frost Crystal each (5x Glass = 200x Frost Crystal) |
+| HoT Ice | 1x Enriched Carbon + 1x Nitrogen Salt |
+| Thermic Condensate | 250x Sulphurine + 50x Condensed Carbon |
+
+### Iridesite
+
+| Alloy | Base Ingredients |
+|---|---|
+| Aronium | 50x Paraffinium + 50x Ionised Cobalt |
+| Magno-gold | 50x Phosphorus + 50x Ionised Cobalt |
+| Grantine | 50x Dioxite + 50x Ionised Cobalt |
+
+## What You Actually Need to Farm
+
+### Gas Extractor Farm
+
+| Gas | Approximate Total Needed |
+|---|---|
+| Sulphurine | 500x+ |
+| Radon | 500x+ |
+| Nitrogen | 500x+ |
+| Condensed Carbon | 300x+ |
+
+Same gas setup as the Fusion Ignitor. Build Gas Extractors on planets with Sulphurine (volcanic/hot), Radon (radioactive), and Nitrogen (frozen). An Electromagnetic Generator keeps them running without fuel.
+
+### Plant Farm (Biodomes or Hydroponics)
+
+| Plant | Total Needed | Native Planet |
+|---|---|---|
+| Gamma Root | 400x | Irradiated |
+| Frost Crystal | 300x | Frozen |
+| Cactus Flesh | 100x | Desert |
+| Star Bulb | 200x | Lush |
+| Solanium | 200x | Fiery/toxic |
+| Faecium | 50x | Any (creature byproduct) |
+
+Gamma Root at 400x is the main farm commitment here. It grows on irradiated planets natively, or in Biodomes anywhere. Frost Crystal at 300x (100 for Heat Capacitor, 200 for Glass) is the second biggest ask. If you already have frozen planet crops running, most of this is covered.
+
+Faecium is easy: creatures drop it on almost any planet, and you only need 50x per craft.
+
+### Planet Mining
+
+| Material | Source |
+|---|---|
+| Paraffinium | Lush planet surface |
+| Phosphorus | Fiery/volcanic planet surface |
+| Dioxite | Frozen planet surface |
+| Ionised Cobalt | Underground caves (150x total) |
+
+Paraffinium, Phosphorus, and Dioxite all come from common planet types. Grab bulk stacks when you're visiting those systems, or mine them near your base if your home planet has the right biome.
+
+## Where to Get the Blueprint
+
+Same as the Fusion Ignitor:
+
+1. **Synthesis Lab on the Space Anomaly** — buy blueprints with Nanites. Get all the sub-component blueprints at the same time: Cryogenic Chamber, Quantum Processor, Living Glass, Cryo-pump, Iridesite, and the three alloys.
+2. **Planetary Manufacturing Facilities** — raid them for blueprint drops.
+
+## Crafting Order
+
+Start from base materials and work up:
+
+1. Set up gas extractors for Sulphurine, Radon, and Nitrogen
+2. Plant Gamma Root, Frost Crystal, Cactus Flesh, Star Bulb, and Solanium
+3. Mine Paraffinium, Phosphorus, Dioxite, and Ionised Cobalt
+4. Craft the three alloys (Aronium, Magno-gold, Grantine) to make Iridesite
+5. Refine gases into Thermic Condensate, Enriched Carbon, and Nitrogen Salt
+6. Craft Semiconductor, then Superconductor and HoT Ice
+7. Craft Lubricant and Glass from farm products, combine into Living Glass
+8. Combine Living Glass and Cryo-pump into Cryogenic Chamber
+9. Craft Circuit Board and combine with Superconductor into Quantum Processor
+10. Assemble Stasis Device
+
+The longest wait is the plant farms. Once Gamma Root and Frost Crystal are harvested, everything else assembles quickly.
+
+## Sources
+- Extracted game data
+- [Craftable products](/products)
+- [Crafting calculator](/calculator)
+- [All refiner recipes](/refining)


### PR DESCRIPTION
Three new crafting guides:

- **How to Craft a Fusion Ignitor** (2025-02-18) — Full recipe tree to base materials, farm requirements, crafting order.
- **How to Craft a Stasis Device** (2025-04-22) — Full recipe tree to base materials, farm requirements, crafting order.
- **Fusion Ignitor vs Stasis Device** (2025-07-15) — Side-by-side comparison. Verdict: Stasis Device is easier for most players (Gamma Root farm vs Fungal Mould, and simpler alloy minerals).

All recipes sourced from extracted game data. All posts reviewed for AI patterns.