### PR TITLE
style: improve blog post table UI with NMS dark theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,6 +3345,21 @@
 				}
 			}
 		},
+		"node_modules/astro/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/astro/node_modules/unstorage": {
 			"version": "1.17.4",
 			"resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -188,6 +188,77 @@
     @apply select-none px-4 py-2 block hover:bg-blue-500 hover:text-black  focus:bg-blue-500 focus:text-black
 }
 
+/* ── Blog prose tables ─────────────────────────────────────────────────── */
+.prose table {
+    @apply w-full border-collapse text-sm my-6 rounded-lg overflow-hidden;
+    /* Rounded corners need the overflow:hidden on a wrapping element;
+       the wrapper is applied below via the responsive container. */
+}
+
+.prose table thead {
+    @apply bg-sky-900/60;
+}
+
+.prose table thead th {
+    @apply px-4 py-3 text-left font-semibold text-cyan-200 border-b border-sky-700/80 whitespace-nowrap;
+}
+
+.prose table thead th:first-child {
+    @apply rounded-tl-lg;
+}
+
+.prose table thead th:last-child {
+    @apply rounded-tr-lg;
+}
+
+.prose table tbody tr {
+    @apply border-b border-sky-900/40 transition-colors duration-150;
+}
+
+.prose table tbody tr:nth-child(even) {
+    @apply bg-sky-950/40;
+}
+
+.prose table tbody tr:nth-child(odd) {
+    @apply bg-sky-950/20;
+}
+
+.prose table tbody tr:last-child {
+    @apply border-b-0;
+}
+
+.prose table tbody tr:last-child td:first-child {
+    @apply rounded-bl-lg;
+}
+
+.prose table tbody tr:last-child td:last-child {
+    @apply rounded-br-lg;
+}
+
+.prose table tbody tr:hover {
+    @apply bg-sky-800/30;
+}
+
+.prose table tbody td {
+    @apply px-4 py-3 text-sky-100/90 align-top;
+}
+
+/* First column as a label in comparison tables */
+.prose table tbody td:first-child {
+    @apply font-medium text-white/80;
+}
+
+/* Responsive wrapper injected around <table> in GuideLayout */
+.prose-table-scroll {
+    @apply w-full overflow-x-auto rounded-lg border border-sky-900/50 shadow-lg shadow-black/30 my-6;
+}
+
+.prose-table-scroll table {
+    @apply my-0;
+}
+
+/* ── end Blog prose tables ─────────────────────────────────────────────── */
+
 .disclaimer {
   font-size: 0.8rem;
   color: #fff;

--- a/src/layouts/GuideLayout.astro
+++ b/src/layouts/GuideLayout.astro
@@ -75,9 +75,18 @@ const relatedLinks = guide.data.relatedLinks as { label: string; href: string }[
 					)}
 				</header>
 
-				<div class="prose prose-invert max-w-none prose-headings:text-white prose-a:text-cyan-300 prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
+				<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-a:text-cyan-300 prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
 					<slot />
 				</div>
+				<script>
+					document.querySelectorAll('#guide-content table').forEach((table) => {
+						if (table.parentElement?.classList.contains('prose-table-scroll')) return;
+						const wrapper = document.createElement('div');
+						wrapper.className = 'prose-table-scroll';
+						table.parentNode?.insertBefore(wrapper, table);
+						wrapper.appendChild(table);
+					});
+				</script>
 
 			{relatedLinks.length > 0 && (
 				<section class="mt-10 rounded-lg border border-sky-900/70 bg-sky-950/30 p-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Blog post Markdown tables had zero styling — just raw browser defaults — because `@tailwindcss/typography` is not installed and no `.prose table` rules existed in `main.css`.

## Changes

**`src/assets/css/main.css`**
- Added a `.prose table` rule block with the NMS sky/cyan dark theme:
  - Header row: `bg-sky-900/60` with `text-cyan-200` bold labels
  - Body rows: alternating `bg-sky-950/40` / `bg-sky-950/20` zebra striping
  - Hover state: `bg-sky-800/30` highlight on each row
  - Rounded corners on the table container
  - First column emphasised as a label (`text-white/80`)
- Added `.prose-table-scroll` — a responsive horizontal-scroll wrapper with a rounded border and drop shadow

**`src/layouts/GuideLayout.astro`**
- Added `id="guide-content"` on the prose wrapper div
- Added a small inline `<script>` that wraps every `<table>` inside `#guide-content` with a `prose-table-scroll` div on page load (idempotent guard included)

## Screenshots

[Gravitino Coil crafting table](https://cursor.com/agents/bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_gravitino_coil.webp)
[Fusion Ignitor vs Stasis Device comparison table](https://cursor.com/agents/bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_fusion_comparison.webp)
[Farming requirements table](https://cursor.com/agents/bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_farming.webp)

## Demo

[blog_table_ui_demo.mp4](https://cursor.com/agents/bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_table_ui_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-804b210d-8c41-4b67-8bd4-b3ddd0a26518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

