### PR TITLE
Add blog posts to site search (title + description only)

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,6 +1,7 @@
 ---
 
 const filters = [
+	{ id: 'blog', name: 'Blog' },
 	{ id: 'products', name: 'Products' },
 	{ id: 'technology', name: 'Technology' },
 	{ id: 'upgrades', name: 'Upgrades' },
@@ -28,7 +29,7 @@ const filterLabels = Object.fromEntries(filters.map((filter) => [filter.id, filt
 					<path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd"></path>
 				</svg>
 
-				<input id="search-input" type="text" class="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-white placeholder-gray-400 focus:ring-0 sm:text-sm" placeholder="Search..." role="combobox" aria-expanded="false" aria-controls="options" aria-label="Search items" />
+				<input id="search-input" type="text" class="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-white placeholder-gray-400 focus:ring-0 sm:text-sm" placeholder="Search..." role="combobox" aria-expanded="false" aria-controls="options" aria-label="Search items and blog posts" />
 				<p class="text-sm px-4">Select Categories</p>
 				<div class="flex flex-wrap gap-2 px-4 pb-4 pt-2">
 					{
@@ -124,7 +125,12 @@ const filterLabels = Object.fromEntries(filters.map((filter) => [filter.id, filt
 		try {
 			const searchDataset = await loadSearchDataset();
 			const filteredResults = searchDataset
-				.filter((result) => result.name.toLowerCase().includes(searchTerm))
+				.filter((result) => {
+					const nameMatch = result.name.toLowerCase().includes(searchTerm);
+					const extra =
+						typeof result.searchText === 'string' ? result.searchText.toLowerCase() : '';
+					return nameMatch || extra.includes(searchTerm);
+				})
 				.slice(0, MAX_RESULTS);
 			const groupedResults = groupBy(filteredResults, 'type');
 
@@ -229,7 +235,7 @@ const filterLabels = Object.fromEntries(filters.map((filter) => [filter.id, filt
 		if (!hasResults) {
 			const emptyState = document.createElement('p');
 			emptyState.className = 'text-gray-300';
-			emptyState.textContent = 'No matching items found.';
+			emptyState.textContent = 'No matching results found.';
 			resultsList.appendChild(emptyState);
 		}
 

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -1,7 +1,25 @@
 import type { APIRoute } from 'astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import { getSlug, sort } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import * as dataSources from '@datav2/index.js';
+
+type SearchIndexEntry = {
+	id: string;
+	name: string;
+	type: string;
+	url: string;
+	/** Extra text matched by search (not shown in the UI), e.g. blog meta description */
+	searchText?: string;
+};
+
+function entryMatchesQuery(entry: SearchIndexEntry, query: string): boolean {
+	const haystack = [entry.name, entry.searchText]
+		.filter((part): part is string => typeof part === 'string' && part.trim() !== '')
+		.join('\n')
+		.toLowerCase();
+	return haystack.includes(query) || entry.type.toLowerCase().includes(query);
+}
 
 const getTypeFromUrl = (url?: string): string => {
   if (!url) return 'item';
@@ -15,7 +33,7 @@ const allData = Object.values(dataSources).flatMap((source) => source as Item[])
 const data = sort(allData as Item[]);
 
 // Build search index: only include items with a valid name so search and client filtering work
-const search = data
+const itemSearchEntries: SearchIndexEntry[] = data
 	.filter((item: Item) => item?.Name != null && String(item.Name).trim() !== '')
 	.map((item: Item) => {
 		const url = getSlug(item);
@@ -27,17 +45,24 @@ const search = data
 		};
 	});
 
+const blogPosts: CollectionEntry<'blog'>[] = await getCollection('blog');
+const blogSearchEntries: SearchIndexEntry[] = blogPosts
+	.filter((post: CollectionEntry<'blog'>) => post.data.title != null && String(post.data.title).trim() !== '')
+	.map((post: CollectionEntry<'blog'>) => ({
+		id: `blog:${post.id}`,
+		name: post.data.title,
+		type: 'blog',
+		url: `/blog/${post.id}`,
+		searchText: post.data.description,
+	}));
+
+const search: SearchIndexEntry[] = [...itemSearchEntries, ...blogSearchEntries];
+
 export const GET: APIRoute = ({ request }) => {
   const url = new URL(request.url);
   const query = url.searchParams.get('q')?.toLowerCase();
 
-  const results = query
-    ? search.filter(
-        (item) =>
-          (typeof item.name === 'string' && item.name.toLowerCase().includes(query)) ||
-          (typeof item.type === 'string' && item.type.toLowerCase().includes(query))
-      )
-    : search;
+  const results = query ? search.filter((item) => entryMatchesQuery(item, query)) : search;
 
   return new Response(
     JSON.stringify({ body: results }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Blog posts are now included in `/search.json` and the header search modal. Matching uses only frontmatter **title** and **description** (the meta description field in each post’s YAML), not the full markdown body, so long-form content does not pollute matches.

## UI

- Added a **Blog** checkbox filter alongside existing item type filters.
- Search input `aria-label` updated to reflect items and blog posts.
- Empty state copy generalized to “No matching results found.”

## Technical notes

- Each blog row uses `type: "blog"`, `url: /blog/{slug}`, and optional `searchText` for the description (used for matching; the list still shows the post title as the link text).
- Server-side `?q=` filtering on `search.json` uses the same title + description + type logic as the client.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71108a07-1135-49f4-9149-9b7a657a8625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71108a07-1135-49f4-9149-9b7a657a8625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

