### PR TITLE
Style blog post links (body and tables)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -257,6 +257,12 @@
     @apply my-0;
 }
 
+/* Blog markdown links: global `a { color: inherit; text-decoration: inherit }`
+   would otherwise make body and table links indistinguishable from text. */
+#guide-content a {
+    @apply text-sky-400 underline decoration-sky-400/70 underline-offset-[3px] transition-colors hover:text-sky-300 hover:decoration-sky-300/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400;
+}
+
 /* ── end Blog prose tables ─────────────────────────────────────────────── */
 
 .disclaimer {

--- a/src/layouts/GuideLayout.astro
+++ b/src/layouts/GuideLayout.astro
@@ -92,7 +92,7 @@ const relatedLinks = guide.data.relatedLinks as { label: string; href: string }[
 		<div class="flex justify-center gap-8 xl:items-start">
 			<div class="w-full max-w-[680px] min-w-0">
 
-				<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-a:text-cyan-300 prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
+				<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
 					<slot />
 				</div>
 				<script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Blog markdown lives in `#guide-content` inside `GuideLayout`. The global base layer sets all anchors to `color: inherit` and `text-decoration: inherit`, which made in-post links—including links inside tables—look like plain text.

## Changes

- Add scoped rules in `src/assets/css/main.css` for `#guide-content a`: sky blue color, underline with slight transparency, hover brightening, and a visible focus ring for keyboard users.
- Remove `prose-a:text-cyan-300` from the guide content wrapper since styling is now centralized in CSS (and the global reset was overriding it anyway).

## Testing

- `npm run lint`
- `npm run type-check`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d15949d-59f1-4d97-a1c6-6a3d4de7c582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d15949d-59f1-4d97-a1c6-6a3d4de7c582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

