### PR TITLE
fix(seo): add initial-scale to viewport and lastmod to sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,9 @@ export default defineConfig({
     }),
     sitemap({
       filter: shouldIncludeInSitemap,
+      lastmod: new Date(),
+      changefreq: 'weekly',
+      priority: 0.7,
     })
   ],
   vite: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -76,7 +76,7 @@ inject();
 <html lang="en" class="h-full  bg-black font-nms text-lg text-white">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/png" href="/images/icon.png" sizes="32x32" />
 		<link rel="canonical" href={canonicalURL} />
 		<link rel="sitemap" href="/sitemap-index.xml" />


### PR DESCRIPTION
## Summary

Two small SEO fixes surfaced by an audit of the live site.

### 1. Viewport meta — add `initial-scale=1`
`src/layouts/Layout.astro` shipped `<meta name="viewport" content="width=device-width">` without `initial-scale=1`. Some mobile browsers then render at the wrong zoom level. Now `width=device-width, initial-scale=1`.

### 2. Sitemap — add `lastmod` / `changefreq` / `priority`
The `@astrojs/sitemap` config had no `lastmod`, so all **5,003** sitemap URLs shipped with no `<lastmod>` — removing the strongest signal Google uses to prioritize recrawls on a large site. Added `lastmod`, `changefreq: 'weekly'`, and `priority: 0.7`.

## Verification
- `pnpm run build` — clean, 5,093 pages built
- `pnpm run type-check` — clean
- Built `dist/index.html` shows the corrected viewport tag
- All 5,003 URLs in `dist/sitemap-0.xml` now carry `lastmod`/`changefreq`/`priority`

## Not included
The expired `www.nomansskyrecipes.com` SSL cert (also found in the audit) is a Vercel/DNS dashboard fix, not a code change, so it's out of scope for this PR.