### PR TITLE
feat: show plant growing time on harvest item pages

### DIFF
--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -8,6 +8,7 @@ import { getItemUpdateMeta } from '@utils/updateChanges';
 import { SITE } from '@config';
 import { getById, findOutput, findInputFromRefiner, findInputFromCooking, findInputFromCrafting, getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
+import { getGrowTimeHeader, getPlantGrowTime } from '@utils/plantGrowTime.js';
 import credit from '../assets/img/credits.png';
 
 // Define the props interface
@@ -421,6 +422,8 @@ const catchChancePercent =
   typeof fishItem.MissionCatchChanceOverride === 'number' && fishItem.MissionCatchChanceOverride > 0
     ? `${(fishItem.MissionCatchChanceOverride * 100).toLocaleString()}%`
     : undefined;
+const plantGrowTime = getPlantGrowTime(item.Id);
+const growTimeHeader = getGrowTimeHeader();
 
 const toHowToIngredients = (inputs: IOItem[]): HowToIngredient[] =>
   inputs.reduce<HowToIngredient[]>((acc, input) => {
@@ -932,6 +935,14 @@ const corvetteAttributes = [
               Catch Chance: {catchChancePercent}
             </p>
           )}
+        </div>
+      )}
+
+      {plantGrowTime && (
+        <div class="mt-4 flex flex-wrap gap-2">
+          <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
+            {growTimeHeader}: {plantGrowTime}
+          </p>
         </div>
       )}
 

--- a/src/utils/plantGrowTime.ts
+++ b/src/utils/plantGrowTime.ts
@@ -1,0 +1,65 @@
+import products from '../datav2/Products.json';
+import localization from '../datav2/localization.json';
+import type { Item } from './lookup';
+
+const GROW_TIME_RE = /Approximate growing time:\s*(.+)/;
+
+/** Seeds whose harvest item is not listed in RequiredItems as PLANT_* / NIPNIPBUDS. */
+const SEED_HARVEST_OVERRIDES: Record<string, string> = {
+	CREATUREPLANT: 'CREATURE1',
+	GRAVPLANT: 'GRAVBALL',
+	SACVENOMPLANT: 'SACVENOM',
+	PEARLPLANT: 'ALBUMENPEARL',
+};
+
+const localizationStrings = localization as Record<string, string>;
+
+function parseGrowTime(description: string): string | undefined {
+	const match = description.match(GROW_TIME_RE);
+	return match?.[1]?.trim();
+}
+
+function resolveHarvestId(seed: Item): string | undefined {
+	const override = SEED_HARVEST_OVERRIDES[seed.Id];
+	if (override) {
+		return override;
+	}
+
+	const harvestItem = seed.RequiredItems?.find(
+		(item) => item.Id.startsWith('PLANT_') || item.Id === 'NIPNIPBUDS',
+	);
+	return harvestItem?.Id;
+}
+
+function buildPlantGrowTimeLookup(): Record<string, string> {
+	const lookup: Record<string, string> = {};
+
+	for (const product of products as Item[]) {
+		let growTime = parseGrowTime(product.Description ?? '');
+
+		if (!growTime && product.Id === 'NIPPLANT') {
+			growTime = parseGrowTime(localizationStrings.UI_PLANTPROD_NIP_DESC ?? '');
+		}
+
+		if (!growTime) {
+			continue;
+		}
+
+		const harvestId = resolveHarvestId(product);
+		if (harvestId) {
+			lookup[harvestId] = growTime;
+		}
+	}
+
+	return lookup;
+}
+
+const plantGrowTimeByHarvestId = buildPlantGrowTimeLookup();
+
+export function getPlantGrowTime(itemId: string): string | undefined {
+	return plantGrowTimeByHarvestId[itemId];
+}
+
+export function getGrowTimeHeader(): string {
+	return localizationStrings.GROWTIME_HEADER ?? 'Growing Time';
+}


### PR DESCRIPTION
## Summary

A site user requested showing plant **growing time** on plant descriptions ("You can see it in-game by looking at the growing plant through the visor").

It turned out the data was **already in the repo** — but only as prose inside the plant *seed* descriptions in `Products.json`, so it appeared on seed product pages and was missing from the **harvest** pages users actually browse (Frost Crystal, Star Bulb, NipNip Buds, etc.).

## Changes

- **`src/utils/plantGrowTime.ts`** (new) — build-time lookup that:
  - parses `Approximate growing time: …` from each seed's `Description`
  - maps seed → harvest item via `RequiredItems` (`PLANT_*` / `NIPNIPBUDS`), with overrides for seeds whose harvest isn't a `PLANT_` id (Mordite, Gravitino Balls, Venom Urchin, Albumen Pearl)
  - backfills NipNip from `UI_PLANTPROD_NIP_DESC` in `localization.json`
- **`src/layouts/Page.astro`** — renders a **Growing Time** pill (mirroring the existing `FishingTime` pill), wired to the previously-unused `GROWTIME_HEADER` localization string.

No data-schema change; no upstream scraper needed (this repo is a data consumer).

## Coverage — 12 plants

| Harvest page | Growing Time |
|---|---|
| Frost Crystal (`/raw/PLANT_SNOW`) | 1 hour |
| Star Bulb (`/raw/PLANT_LUSH`) | 4 hours |
| Gamma Root (`/raw/PLANT_RADIO`) | 4 hours |
| Fungal Mould (`/raw/PLANT_TOXIC`) | 4 hours |
| Faecium (`/raw/PLANT_POOP`) | 4 hours |
| Solanium (`/raw/PLANT_HOT`) | 16 hours |
| Cactus Flesh (`/raw/PLANT_DUST`) | 16 hours |
| Mordite (`CREATURE1`) | 8 hours |
| Gravitino Balls (`GRAVBALL`) | 2 hours |
| Venom Urchin (`SACVENOM`) | 3 hours 20 mins |
| Albumen Pearl (`ALBUMENPEARL`) | 80 mins |
| NipNip Buds (`/curiosities/NIPNIPBUDS`) | 60 mins |

## Verification

- `pnpm run type-check` — pass
- `pnpm run lint` — no issues in changed files (one pre-existing unrelated error in `src/pages/index.astro`)
- `pnpm run build` — pass, 5,093 pages
- Pill confirmed in built HTML and on the live dev server (e.g. Frost Crystal → "Growing Time: 1 hour")

## Notes / possible follow-ups

- For values that must exactly match the in-game visor numbers, a structured `GrowTime` field from the upstream data extractor would be the long-term path — but the localization prose times are accurate for site use.
- Seed product pages already showed the time in prose; this PR closes the gap on harvest/curiosity pages.

🤖 Implemented with Cursor CLI, reviewed & verified before commit.