### PR TITLE
feat: discovery + SEO batch — category filters, hub schema, affinity links, sitemap polish, farm calculator

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 
 import react from "@astrojs/react";
+import { SITE } from './src/config.ts';
 
 const SITEMAP_EXCLUDED_PATHS = new Set([
   '/feedback',
@@ -22,10 +23,6 @@ const shouldIncludeInSitemap = (page) => {
     return false;
   }
 
-  if (pathname.startsWith('/creatures/species/')) {
-    return false;
-  }
-
   if (pathname.startsWith('/guides/')) {
     return false;
   }
@@ -42,7 +39,7 @@ export default defineConfig({
     }),
     sitemap({
       filter: shouldIncludeInSitemap,
-      lastmod: new Date(),
+      lastmod: new Date(SITE.version_date),
       changefreq: 'weekly',
       priority: 0.7,
     })

--- a/src/components/CategoryFilter.astro
+++ b/src/components/CategoryFilter.astro
@@ -1,0 +1,405 @@
+---
+import { SITE } from '@config';
+
+interface Props {
+	type: string;
+	basePath: string;
+}
+
+const { type, basePath } = Astro.props;
+const IMAGE_BASE = SITE.imageBaseUrl;
+const idPrefix = type.replace(/[^a-z0-9]/gi, '-');
+---
+
+<form
+	class="mx-auto max-w-4xl mb-8 flex flex-wrap gap-4 justify-center items-center"
+	data-category-filter={type}
+>
+	<div class="relative" id={`${idPrefix}-group-combobox-wrapper`}>
+		<label for={`${idPrefix}-group-input`} class="sr-only">Group</label>
+		<input
+			id={`${idPrefix}-group-input`}
+			type="text"
+			autocomplete="off"
+			placeholder="All groups"
+			role="combobox"
+			aria-expanded="false"
+			aria-controls={`${idPrefix}-group-dropdown`}
+			aria-autocomplete="list"
+			class="h-10 w-48 rounded-sm border border-sky-700 bg-sky-900/50 px-3 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+		/>
+		<div
+			id={`${idPrefix}-group-dropdown`}
+			role="listbox"
+			class="absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-sm border border-sky-700 bg-sky-900 shadow-lg hidden"
+		></div>
+	</div>
+	<div>
+		<label for={`${idPrefix}-search-input`} class="sr-only">Search</label>
+		<input
+			id={`${idPrefix}-search-input`}
+			type="text"
+			placeholder="Search by name..."
+			class="h-10 w-48 rounded-sm border border-sky-700 bg-sky-900/50 px-3 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+		/>
+	</div>
+	<div class="flex gap-2">
+		<button
+			id={`${idPrefix}-apply-filters`}
+			type="button"
+			class="h-10 rounded-sm bg-sky-600 px-4 font-semibold text-white transition-colors hover:bg-sky-500"
+		>
+			Apply
+		</button>
+		<button
+			id={`${idPrefix}-reset-filters`}
+			type="button"
+			class="h-10 rounded-sm border border-sky-600 px-4 font-semibold text-sky-400 transition-colors hover:bg-sky-900/50 hover:text-white"
+		>
+			Reset
+		</button>
+	</div>
+</form>
+
+<div id={`${idPrefix}-loading`} class="text-center py-12 text-sky-400" aria-live="polite">Loading...</div>
+<div id={`${idPrefix}-empty`} class="hidden text-center py-12 text-sky-400" aria-live="polite">
+	No items found. Try adjusting your filters.
+</div>
+<div id={`${idPrefix}-error`} class="hidden text-center py-12" aria-live="assertive">
+	<p class="text-sky-400 mb-4">Failed to load items. Please try again.</p>
+	<button
+		id={`${idPrefix}-retry-btn`}
+		type="button"
+		class="rounded-sm bg-sky-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-sky-500"
+	>
+		Retry
+	</button>
+</div>
+<div id={`${idPrefix}-items-container`} class="hidden">
+	<div
+		id={`${idPrefix}-items`}
+		class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 px-2"
+	></div>
+	<div id={`${idPrefix}-load-more-sentinel`} class="h-1 w-full" aria-hidden="true"></div>
+</div>
+
+<script define:vars={{ IMAGE_BASE, type, basePath, idPrefix }}>
+	const PAGE_SIZE = 80;
+	const groupInput = document.getElementById(`${idPrefix}-group-input`);
+	const groupDropdown = document.getElementById(`${idPrefix}-group-dropdown`);
+	const searchInput = document.getElementById(`${idPrefix}-search-input`);
+	const applyBtn = document.getElementById(`${idPrefix}-apply-filters`);
+	const resetBtn = document.getElementById(`${idPrefix}-reset-filters`);
+	const loadingEl = document.getElementById(`${idPrefix}-loading`);
+	const emptyEl = document.getElementById(`${idPrefix}-empty`);
+	const errorEl = document.getElementById(`${idPrefix}-error`);
+	const retryBtn = document.getElementById(`${idPrefix}-retry-btn`);
+	const itemsContainer = document.getElementById(`${idPrefix}-items-container`);
+	const itemsEl = document.getElementById(`${idPrefix}-items`);
+	const loadMoreSentinel = document.getElementById(`${idPrefix}-load-more-sentinel`);
+
+	let allItemsData = [];
+	let allGroups = [];
+	let filteredItems = [];
+	let displayedCount = 0;
+	let scrollObserver = null;
+
+	function escapeHtml(str) {
+		if (str == null) return '';
+		const s = String(str);
+		return s
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
+
+	function getParams() {
+		const params = new URLSearchParams(window.location.search);
+		return {
+			group: params.get('group') || '',
+			q: params.get('q') || '',
+		};
+	}
+
+	function syncInputsFromUrl() {
+		const { group, q } = getParams();
+		if (groupInput) groupInput.value = group;
+		if (searchInput) searchInput.value = q;
+	}
+
+	function updateUrl() {
+		const group = groupInput?.value?.trim() || '';
+		const q = searchInput?.value?.trim() || '';
+		const params = new URLSearchParams();
+		if (group) params.set('group', group);
+		if (q) params.set('q', q);
+		const query = params.toString();
+		const newUrl = `${basePath}${query ? '?' + query : ''}`;
+		window.history.replaceState({}, '', newUrl);
+	}
+
+	function renderDropdown(list, filter, dropdownId) {
+		const q = (filter || '').toLowerCase().trim();
+		const filtered = list.filter((item) => item.toLowerCase().includes(q));
+		const items = filtered.map(
+			(item, i) =>
+				`<div role="option" id="${dropdownId}-opt-${i + 1}" tabindex="-1" class="block w-full px-3 py-2 text-left text-sm text-white hover:bg-sky-700/80 cursor-pointer" data-value="${escapeHtml(item)}">${escapeHtml(item)}</div>`
+		);
+		const clearBtn = `<div role="option" id="${dropdownId}-opt-0" tabindex="-1" class="block w-full px-3 py-2 text-left text-sm text-sky-400 hover:bg-sky-700/80 cursor-pointer" data-value="">(All)</div>`;
+		return clearBtn + items.join('');
+	}
+
+	function setupCombobox(inputEl, dropdownEl, getOptions, onSelect) {
+		if (!inputEl || !dropdownEl) return;
+		const dropdownId = dropdownEl.id;
+		let activeIndex = -1;
+
+		function getOptionEls() {
+			return dropdownEl.querySelectorAll('[role="option"]');
+		}
+
+		function setActiveOption(index) {
+			const options = getOptionEls();
+			options.forEach((opt) => opt.classList.remove('bg-sky-700/80'));
+			activeIndex = index;
+			if (index >= 0 && index < options.length) {
+				const opt = options[index];
+				opt.classList.add('bg-sky-700/80');
+				opt.scrollIntoView({ block: 'nearest' });
+				inputEl.setAttribute('aria-activedescendant', opt.id);
+			} else {
+				inputEl.removeAttribute('aria-activedescendant');
+			}
+		}
+
+		function selectOption(optionEl) {
+			inputEl.value = optionEl.dataset.value || '';
+			hide();
+			onSelect();
+		}
+
+		function show() {
+			const options = getOptions();
+			dropdownEl.innerHTML = renderDropdown(options, inputEl.value, dropdownId);
+			dropdownEl.classList.remove('hidden');
+			inputEl.setAttribute('aria-expanded', 'true');
+			activeIndex = -1;
+			inputEl.removeAttribute('aria-activedescendant');
+			dropdownEl.querySelectorAll('[role="option"]').forEach((opt) => {
+				opt.addEventListener('mousedown', (e) => e.preventDefault());
+				opt.addEventListener('click', () => selectOption(opt));
+			});
+		}
+
+		function hide() {
+			dropdownEl.classList.add('hidden');
+			inputEl.setAttribute('aria-expanded', 'false');
+			activeIndex = -1;
+			inputEl.removeAttribute('aria-activedescendant');
+		}
+
+		inputEl.addEventListener('focus', show);
+		inputEl.addEventListener('input', show);
+		inputEl.addEventListener('blur', hide);
+		dropdownEl.addEventListener('mousedown', (e) => e.preventDefault());
+
+		inputEl.addEventListener('keydown', (e) => {
+			const options = getOptionEls();
+			if (!options.length) return;
+			const isOpen = !dropdownEl.classList.contains('hidden');
+
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				if (!isOpen) {
+					show();
+					return;
+				}
+				setActiveOption(Math.min(activeIndex + 1, options.length - 1));
+			} else if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				if (!isOpen) return;
+				setActiveOption(Math.max(activeIndex - 1, 0));
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				hide();
+			} else if (e.key === 'Enter' && isOpen) {
+				e.preventDefault();
+				if (activeIndex >= 0) {
+					selectOption(options[activeIndex]);
+				} else {
+					hide();
+					onSelect();
+				}
+			}
+		});
+	}
+
+	function resetFilters() {
+		if (groupInput) groupInput.value = '';
+		if (searchInput) searchInput.value = '';
+		groupDropdown?.classList.add('hidden');
+		loadItems();
+	}
+
+	function renderCard(item) {
+		const name = escapeHtml(item.name);
+		const icon = escapeHtml(item.icon || '');
+		const rawUrl = item.url || '';
+		const url = escapeHtml(rawUrl.startsWith('/') && !rawUrl.includes('//') ? rawUrl : '#');
+		const article = document.createElement('article');
+		article.className = 'group relative';
+		article.innerHTML = `
+			<a
+				href="${url}"
+				class="group block h-full overflow-hidden rounded-xs border border-sky-900 bg-sky-800/80 transition hover:-translate-y-0.5 hover:border-sky-400 hover:bg-sky-700/90"
+			>
+				<div class="aspect-square bg-[#0b3550]">
+					<img
+						class="h-full w-full object-contain object-center"
+						src="${IMAGE_BASE}${icon}"
+						alt="${name}"
+						loading="lazy"
+						width="128"
+						height="128"
+					/>
+				</div>
+				<div class="border-t border-sky-900 px-2 py-1.5">
+					<p class="truncate text-base font-semibold text-white/95" title="${name}">${name}</p>
+				</div>
+			</a>
+		`;
+		return article;
+	}
+
+	function filterItems(items, group, q) {
+		let filtered = items.filter((item) => (item.url || '').split('/')[1] === type);
+		if (group) {
+			const g = group.trim().toLowerCase();
+			filtered = filtered.filter(
+				(item) => item.group && String(item.group).toLowerCase().includes(g)
+			);
+		}
+		if (q) {
+			const search = q.toLowerCase().trim();
+			filtered = filtered.filter(
+				(item) =>
+					(item.name && String(item.name).toLowerCase().includes(search)) ||
+					(item.group && String(item.group).toLowerCase().includes(search))
+			);
+		}
+		return filtered;
+	}
+
+	function renderNextBatch() {
+		const start = displayedCount;
+		const end = Math.min(displayedCount + PAGE_SIZE, filteredItems.length);
+		for (let i = start; i < end; i++) {
+			itemsEl?.appendChild(renderCard(filteredItems[i]));
+		}
+		displayedCount = end;
+		if (loadMoreSentinel) {
+			loadMoreSentinel.classList.toggle('hidden', displayedCount >= filteredItems.length);
+		}
+	}
+
+	function setupScrollObserver() {
+		if (!loadMoreSentinel || scrollObserver) return;
+		scrollObserver = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || displayedCount >= filteredItems.length) return;
+				renderNextBatch();
+			},
+			{ rootMargin: '600px', threshold: 0 }
+		);
+		scrollObserver.observe(loadMoreSentinel);
+	}
+
+	async function loadItems(forceFetch = false) {
+		if (!loadingEl || !emptyEl || !itemsEl || !itemsContainer) return;
+
+		loadingEl.classList.remove('hidden');
+		emptyEl.classList.add('hidden');
+		errorEl?.classList.add('hidden');
+		itemsContainer.classList.add('hidden');
+		itemsEl.innerHTML = '';
+
+		const q = searchInput?.value?.trim() || '';
+
+		try {
+			const needsFetch = forceFetch || allItemsData.length === 0;
+			if (needsFetch) {
+				const res = await fetch(`/items.json?type=${encodeURIComponent(type)}`);
+				const json = await res.json();
+				const allItems = json?.body ?? [];
+				const categoryItems = allItems.filter(
+					(item) => (item.url || '').split('/')[1] === type
+				);
+
+				allItemsData = categoryItems;
+				allGroups = [...new Set(categoryItems.map((i) => i.group).filter(Boolean))].sort();
+			}
+
+			const needsSetup = !groupDropdown?.dataset.ready;
+			if (needsSetup) {
+				groupDropdown.dataset.ready = '1';
+				setupCombobox(groupInput, groupDropdown, () => allGroups, () => loadItems());
+				syncInputsFromUrl();
+			}
+
+			const groupVal = groupInput?.value?.trim() || '';
+			const items = filterItems(allItemsData, groupVal, q);
+
+			loadingEl.classList.add('hidden');
+
+			if (items.length === 0) {
+				emptyEl.classList.remove('hidden');
+			} else {
+				filteredItems = items;
+				displayedCount = 0;
+				renderNextBatch();
+				itemsContainer.classList.remove('hidden');
+				if (filteredItems.length > PAGE_SIZE) {
+					setupScrollObserver();
+				} else if (scrollObserver) {
+					scrollObserver.disconnect();
+					scrollObserver = null;
+				}
+			}
+
+			updateUrl();
+		} catch (err) {
+			console.error('Failed to load items:', err);
+			loadingEl.classList.add('hidden');
+			errorEl?.classList.remove('hidden');
+		}
+	}
+
+	applyBtn?.addEventListener('click', (e) => {
+		e.preventDefault();
+		loadItems();
+	});
+	resetBtn?.addEventListener('click', (e) => {
+		e.preventDefault();
+		resetFilters();
+	});
+
+	searchInput?.addEventListener('keydown', (e) => {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			loadItems();
+		}
+	});
+	groupInput?.addEventListener('keydown', (e) => {
+		if (e.key === 'Enter' && groupDropdown?.classList.contains('hidden')) {
+			e.preventDefault();
+			loadItems();
+		}
+	});
+
+	retryBtn?.addEventListener('click', () => loadItems(true));
+
+	loadItems();
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,8 @@ export interface Props {
 	structuredData?: JsonLdObject | JsonLdObject[];
 	robots?: string;
 	canonical?: string;
+	prevUrl?: string;
+	nextUrl?: string;
 }
 
 const {
@@ -35,6 +37,8 @@ const {
 	articleModifiedTime,
 	robots = 'index,follow,max-image-preview:large',
 	canonical,
+	prevUrl,
+	nextUrl,
 } = Astro.props;
 const canonicalURL = canonical
 	? new URL(canonical, SITE.website)
@@ -85,6 +89,8 @@ inject();
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/png" href="/images/icon.png" sizes="32x32" />
 		<link rel="canonical" href={canonicalURL} />
+		{prevUrl && <link rel="prev" href={prevUrl} />}
+		{nextUrl && <link rel="next" href={nextUrl} />}
 		<link rel="sitemap" href="/sitemap-index.xml" />
 		<meta name="generator" content={Astro.generator} />
 

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   BugAntIcon,
   BookOpenIcon,
   SparklesIcon,
+  SunIcon,
 } from '@heroicons/react/24/solid';
 import type { ComponentType, SVGProps } from 'react';
 import { classNames } from '../utils/classNames';
@@ -52,6 +53,7 @@ const navigation: NavigationItem[] = [
   { name: 'Blog', href: '/blog', icon: BookOpenIcon },
   { name: 'New Items', href: '/new', icon: SparklesIcon },
   { name: 'Calculator', href: '/calculator', icon: CalculatorIcon },
+  { name: 'Farm Calculator', href: '/farm', icon: SunIcon },
   { name: 'Products', href: '/products', icon: ArchiveBoxIcon },
   { name: 'Technology', href: '/technology', icon: CogIcon },
   { name: 'Upgrades', href: '/upgrades', icon: WrenchIcon },

--- a/src/pages/buildings/[page].astro
+++ b/src/pages/buildings/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Buildings.json';
 import { SITE } from '@config';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of building parts for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Building Parts', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Building Parts', baseDescript
 	{description}
 	slug="buildings"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Building Parts</h1>

--- a/src/pages/buildings/index.astro
+++ b/src/pages/buildings/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Buildings.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of building parts for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Building Parts', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Building Parts', baseDescript
 	{description}
 	slug="buildings"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Building Parts</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="buildings" basePath="/buildings" />
 </Layout>

--- a/src/pages/calculator/[page].astro
+++ b/src/pages/calculator/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Products.json';
 import { SITE } from '@config';
@@ -52,6 +52,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = 'A calculator to help your farming efforts by calculating exactly what you need to craft any item.';
 const { title, description } = buildPaginatedMeta('Crafting Calculator', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -59,6 +60,8 @@ const { title, description } = buildPaginatedMeta('Crafting Calculator', baseDes
 	{description}
 	slug="calculator"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Calculator</h1>

--- a/src/pages/calculator/index.astro
+++ b/src/pages/calculator/index.astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Products.json';
 import { SITE } from '@config';
@@ -48,6 +48,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = 'A calculator to help your farming efforts by calculating exactly what you need to craft any item.';
 const { title, description } = buildPaginatedMeta('Crafting Calculator', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -55,6 +56,7 @@ const { title, description } = buildPaginatedMeta('Crafting Calculator', baseDes
 	{description}
 	slug="calculator"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 	ogImage={`${SITE.website}/images/calculator.webp`}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />

--- a/src/pages/cooking/index.astro
+++ b/src/pages/cooking/index.astro
@@ -4,9 +4,10 @@
 import Layout from '@layouts/Layout.astro';
 import Table from '@components/table/Table.astro';
 import processor from '@datav2/NutrientProcessor.json';
-import { getById } from '@utils/lookup.js';
+import { getById, getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import type { TableRow } from '@components/table/Table.astro';
+import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
 import { SITE } from '@config';
 
 // Interfaces for defining the shape of input and output objects
@@ -103,13 +104,36 @@ const columns = [
 
 // Map the data and create an array of filtered items
 const data = processor.map(createArray).filter((item): item is TableItem => item !== undefined);
+
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/cooking', siteOrigin).toString();
+const baseDescription =
+	"Browse No Man's Sky cooking recipes, ingredient combinations, and Nutrient Processor outputs to find the best food recipes and ingredient chains.";
+const itemListElements = data.slice(0, 25).map((row, index) => {
+	const outputItem = getById(row.output.id);
+	return {
+		name: row.output.name,
+		url: outputItem ? `${siteOrigin}${getSlug(outputItem)}` : canonicalUrl,
+		position: index + 1,
+	};
+});
+const structuredData = buildCollectionStructuredData({
+	siteOrigin,
+	canonicalUrl,
+	collectionName: 'Cooking Recipes',
+	collectionDescription: baseDescription,
+	collectionPath: '/cooking',
+	currentPage: 1,
+	items: itemListElements,
+});
 ---
 
 <Layout
 	title={"Cooking Recipes | No Man's Sky Recipes"}
-	description="Browse No Man's Sky cooking recipes, ingredient combinations, and Nutrient Processor outputs to find the best food recipes and ingredient chains."
+	description={baseDescription}
 	slug="cooking"
 	ogImage={`${SITE.website}/images/cooker.webp`}
+	structuredData={structuredData}
 >
 	<Table title="Cooking" image="cooking" image_width={60} image_height={60} columns={columns} data={data} />
 </Layout>

--- a/src/pages/corvette/[page].astro
+++ b/src/pages/corvette/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import none from '@datav2/Corvette.json';
 import { SITE } from '@config';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of corvette items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Corvette Items', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Corvette Items', baseDescript
 	{description}
 	slug="corvette"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Corvette Items</h1>

--- a/src/pages/corvette/index.astro
+++ b/src/pages/corvette/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Corvette.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of corvette items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Corvette Items', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Corvette Items', baseDescript
 	{description}
 	slug="corvette"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Corvette Items</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: `${SITE.imageBaseUrl}${item.Icon}`,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="corvette" basePath="/corvette" />
 </Layout>

--- a/src/pages/crafting-guide/index.astro
+++ b/src/pages/crafting-guide/index.astro
@@ -3,9 +3,10 @@
 import Layout from '@layouts/Layout.astro';
 import Table from '@components/table/Table.astro';
 import products from '@datav2/Products.json';
-import { getById } from '@utils/lookup.js';
+import { getById, getSlug } from '@utils/lookup.js';
 import type { Item, RequiredItem } from '@utils/lookup.js';
 import type { TableRow } from '@components/table/Table.astro';
+import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
 import { SITE } from '@config';
 
 interface ItemDetails {
@@ -60,13 +61,35 @@ const columns = [
 // Map the data and create an array of filtered items with proper type guard
 const data = products.map(createArray).filter((item): item is TableRow => item !== undefined);
 
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/crafting-guide', siteOrigin).toString();
+const baseDescription =
+	"Browse the No Man's Sky crafting guide for product recipes, ingredient chains, unit values, and step-by-step crafting paths.";
+const itemListElements = data.slice(0, 25).map((row, index) => {
+	const outputItem = getById(row.output.id);
+	return {
+		name: row.output.name,
+		url: outputItem ? `${siteOrigin}${getSlug(outputItem)}` : canonicalUrl,
+		position: index + 1,
+	};
+});
+const structuredData = buildCollectionStructuredData({
+	siteOrigin,
+	canonicalUrl,
+	collectionName: 'Crafting Guide',
+	collectionDescription: baseDescription,
+	collectionPath: '/crafting-guide',
+	currentPage: 1,
+	items: itemListElements,
+});
 ---
 
 <Layout
 	title="Crafting Guide | No Man's Sky Recipes"
-	description="Browse the No Man's Sky crafting guide for product recipes, ingredient chains, unit values, and step-by-step crafting paths."
+	description={baseDescription}
 	slug="crafting-guide"
 	ogImage={`${SITE.website}/images/crafting.webp`}
+	structuredData={structuredData}
 >
 		<Table
 			title="Crafting"

--- a/src/pages/creatures/affinities.astro
+++ b/src/pages/creatures/affinities.astro
@@ -26,6 +26,8 @@ const matchups = [
 const displayNameFor = (affinityId: string): string =>
 	affinityById.get(affinityId)?.DisplayName ?? affinityId;
 const iconFor = (affinityId: string): string | null => affinityById.get(affinityId)?.Icon ?? null;
+const speciesFilterUrl = (affinityId: string): string =>
+	`/creatures/species?affinity=${encodeURIComponent(displayNameFor(affinityId))}`;
 
 const title = "Creature Affinities | No Man's Sky Recipes";
 const description =
@@ -41,27 +43,39 @@ const breadcrumbs = [
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<section class="mx-auto max-w-6xl px-4 pb-10">
 		<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Affinity System</h1>
-		<p class="mx-auto mb-10 max-w-4xl text-center text-sky-200/90">
+		<p class="mx-auto mb-6 max-w-4xl text-center text-sky-200/90">
 			Winning Arena battles depends on affinity matchups. Use this chart to plan favorable counters and
 			avoid weak pairings.
+		</p>
+		<p class="mx-auto mb-10 max-w-4xl text-center">
+			<a
+				href="/creatures/species"
+				class="text-sky-400 underline decoration-sky-600/50 underline-offset-2 hover:text-sky-300"
+			>
+				Browse all creature species
+			</a>
 		</p>
 
 		<div class="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-8">
 			{
 				matchups.map((row) => {
 					const icon = iconFor(row.affinityId);
+					const displayName = displayNameFor(row.affinityId);
 					return (
-						<div class="rounded-sm border border-sky-800/70 bg-sky-950/40 px-3 py-4 text-center">
+						<a
+							href={speciesFilterUrl(row.affinityId)}
+							class="rounded-sm border border-sky-800/70 bg-sky-950/40 px-3 py-4 text-center transition hover:border-sky-500 hover:bg-sky-900/50"
+						>
 							{icon && (
 								<img
 									src={`${IMAGE_BASE}${icon}`}
-									alt={`${displayNameFor(row.affinityId)} icon`}
+									alt={`${displayName} icon`}
 									class="mx-auto mb-2 h-10 w-10"
 									loading="lazy"
 								/>
 							)}
-							<p class="m-0 text-sm font-semibold text-white">{displayNameFor(row.affinityId)}</p>
-						</div>
+							<p class="m-0 text-sm font-semibold text-white">{displayName}</p>
+						</a>
 					);
 				})
 			}
@@ -80,9 +94,30 @@ const breadcrumbs = [
 					{
 						matchups.map((row) => (
 							<tr class="border-t border-sky-800/60 text-sm">
-								<td class="px-4 py-3 text-sky-100">{displayNameFor(row.affinityId)}</td>
-								<td class="px-4 py-3 text-lime-300">{displayNameFor(row.strongAgainstId)}</td>
-								<td class="px-4 py-3 text-amber-300">{displayNameFor(row.weakAgainstId)}</td>
+								<td class="px-4 py-3 text-sky-100">
+									<a
+										href={speciesFilterUrl(row.affinityId)}
+										class="text-sky-300 underline decoration-sky-600/50 underline-offset-2 hover:text-white"
+									>
+										{displayNameFor(row.affinityId)}
+									</a>
+								</td>
+								<td class="px-4 py-3 text-lime-300">
+									<a
+										href={speciesFilterUrl(row.strongAgainstId)}
+										class="underline decoration-lime-600/50 underline-offset-2 hover:text-lime-200"
+									>
+										{displayNameFor(row.strongAgainstId)}
+									</a>
+								</td>
+								<td class="px-4 py-3 text-amber-300">
+									<a
+										href={speciesFilterUrl(row.weakAgainstId)}
+										class="underline decoration-amber-600/50 underline-offset-2 hover:text-amber-200"
+									>
+										{displayNameFor(row.weakAgainstId)}
+									</a>
+								</td>
 							</tr>
 						))
 					}

--- a/src/pages/creatures/species/index.astro
+++ b/src/pages/creatures/species/index.astro
@@ -145,6 +145,14 @@ const { title, description } = buildPaginatedMeta('Creature Species', baseDescri
 
 <Layout title={title} description={description} slug="creatures" structuredData={structuredData}>
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
+	<p class="mx-auto mb-4 max-w-4xl px-4 text-center">
+		<a
+			href="/creatures/affinities"
+			class="text-sky-400 underline decoration-sky-600/50 underline-offset-2 hover:text-sky-300"
+		>
+			← Back to Affinity guide
+		</a>
+	</p>
 
 	<div class="table-wrapper d-hidden" data-layout="table" data-astro-transition-persist="table-wrapper">
 		<div class="card-header p-4 relative flex lg:flex-row flex-col gap-5 items-center justify-between bg-black">
@@ -158,7 +166,17 @@ const { title, description } = buildPaginatedMeta('Creature Species', baseDescri
 				/>
 				<h1 class="text-2xl m-0">Creature Species</h1>
 			</div>
-			<div class="flex items-center z-10">
+			<div class="flex flex-col sm:flex-row items-center gap-3 z-10">
+				<div id="affinity-filter-chip" class="hidden items-center gap-2 rounded-md border border-sky-700 bg-sky-950/60 px-3 py-1.5 text-sm text-sky-200">
+					<span>Filtered by affinity: <strong id="affinity-filter-label"></strong></span>
+					<button
+						id="affinity-filter-clear"
+						type="button"
+						class="rounded-sm border border-sky-600 px-2 py-0.5 text-xs text-sky-400 hover:bg-sky-900/50 hover:text-white"
+					>
+						Clear
+					</button>
+				</div>
 				<div class="tabulator-search relative">
 					<input
 						class="rounded-md w-full bg-black border-blue-500 focus:border-blue-500 focus:ring-blue-500 peer"
@@ -188,7 +206,7 @@ const { title, description } = buildPaginatedMeta('Creature Species', baseDescri
 						const subtitle = s.SpeciesSubtitle?.trim();
 						const displayName = subtitle ? `${s.Name} (${subtitle})` : s.Name;
 						return (
-							<tr>
+							<tr data-affinity={affinity}>
 								<TableCell cell={{
 									id: s.Id,
 									name: displayName,
@@ -269,10 +287,71 @@ const { title, description } = buildPaginatedMeta('Creature Species', baseDescri
 			}
 		});
 
-		function matchAny(data: Record<string, unknown>, filterParams: { value: string }) {
-			const escapedValue = filterParams.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		function affinityFromCell(value: unknown): string {
+			const text = String(value ?? '')
+				.replace(/<[^>]*>/g, ' ')
+				.replace(/&amp;/g, '&')
+				.replace(/\s+/g, ' ')
+				.trim();
+			return (text.split(' ')[0] || '').toLowerCase();
+		}
+
+		function matchFilters(
+			data: Record<string, unknown>,
+			filterParams: { value: string; affinity: string }
+		) {
+			if (
+				filterParams.affinity &&
+				affinityFromCell(data.affinity) !== filterParams.affinity.toLowerCase()
+			) {
+				return false;
+			}
+			const search = filterParams.value.trim();
+			if (!search) return true;
+			const escapedValue = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 			const regex = new RegExp(escapedValue, 'i');
 			return Object.values(data).some((value) => regex.test(String(value)));
+		}
+
+		let activeAffinity = '';
+		const affinityChip = document.getElementById('affinity-filter-chip');
+		const affinityLabel = document.getElementById('affinity-filter-label');
+		const affinityClear = document.getElementById('affinity-filter-clear');
+
+		function applyTableFilter(searchValue: string) {
+			if (!searchValue.trim() && !activeAffinity) {
+				table.clearFilter();
+				return;
+			}
+			table.setFilter(matchFilters, { value: searchValue, affinity: activeAffinity });
+		}
+
+		function setAffinityFilter(affinity: string, updateUrl = true) {
+			activeAffinity = affinity;
+			if (affinityChip && affinityLabel) {
+				if (affinity) {
+					affinityLabel.textContent = affinity;
+					affinityChip.classList.remove('hidden');
+					affinityChip.classList.add('flex');
+				} else {
+					affinityChip.classList.add('hidden');
+					affinityChip.classList.remove('flex');
+					affinityLabel.textContent = '';
+				}
+			}
+			const input = document.getElementById('search') as HTMLInputElement | null;
+			applyTableFilter(input?.value ?? '');
+			if (updateUrl) {
+				const params = new URLSearchParams(window.location.search);
+				if (affinity) {
+					params.set('affinity', affinity);
+				} else {
+					params.delete('affinity');
+				}
+				const query = params.toString();
+				const newUrl = `/creatures/species${query ? '?' + query : ''}`;
+				window.history.replaceState({}, '', newUrl);
+			}
 		}
 
 		const input = document.getElementById('search') as HTMLInputElement;
@@ -283,13 +362,16 @@ const { title, description } = buildPaginatedMeta('Creature Species', baseDescri
 					clearTimeout(debounceTimer);
 				}
 				debounceTimer = setTimeout(() => {
-					if (input.value.trim() === '') {
-						table.clearFilter();
-					} else {
-						table.setFilter(matchAny, { value: input.value });
-					}
+					applyTableFilter(input.value);
 				}, 150);
 			});
+		}
+
+		affinityClear?.addEventListener('click', () => setAffinityFilter(''));
+
+		const initialAffinity = new URLSearchParams(window.location.search).get('affinity')?.trim() ?? '';
+		if (initialAffinity) {
+			setAffinityFilter(initialAffinity, false);
 		}
 	});
 </script>

--- a/src/pages/curiosities/[page].astro
+++ b/src/pages/curiosities/[page].astro
@@ -4,7 +4,7 @@ import CompactCard from '@components/CompactCard.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Curiosities.json';
 import Pagination from '@components/Pagination.astro';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of curiosities for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Curiosities', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Curiosities', baseDescription
 	{description}
 	slug="curiosities"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Curiosities</h1>

--- a/src/pages/curiosities/index.astro
+++ b/src/pages/curiosities/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Curiosities.json';
-import Pagination from '@components/Pagination.astro';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of curiosities for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Curiosities', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,24 +53,10 @@ const { title, description } = buildPaginatedMeta('Curiosities', baseDescription
 	{description}
 	slug="curiosities"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Curiosities</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-
-	<Pagination page={page} />
+	<CategoryFilter type="curiosities" basePath="/curiosities" />
 </Layout>

--- a/src/pages/exocraft/[page].astro
+++ b/src/pages/exocraft/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Exocraft.json';
 import { SITE } from '@config';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of exocraft items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Exocraft', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Exocraft', baseDescription, p
 	{description}
 	slug="exocraft"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Exocraft</h1>

--- a/src/pages/exocraft/index.astro
+++ b/src/pages/exocraft/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Exocraft.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of exocraft items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Exocraft', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Exocraft', baseDescription, p
 	{description}
 	slug="exocraft"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Exocraft</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="exocraft" basePath="/exocraft" />
 </Layout>

--- a/src/pages/farm/index.astro
+++ b/src/pages/farm/index.astro
@@ -1,0 +1,233 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Breadcrumbs from '@components/Breadcrumbs.astro';
+import { getAllGrowablePlants } from '@utils/plantGrowTime.js';
+import { getSiteOrigin } from '@utils/structuredData.js';
+import { SITE } from '@config';
+
+const IMAGE_BASE = SITE.imageBaseUrl;
+const plants = getAllGrowablePlants();
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/farm', siteOrigin).toString();
+const breadcrumbs = [
+	{ name: 'Home', href: '/' },
+	{ name: 'Farm Calculator' },
+];
+const title = "Farm Calculator | No Man's Sky Recipes";
+const description =
+	'Plan your No Man\'s Sky farm plots by grow time and harvest yield. Select plants, set plot counts, and see total real-time duration and output.';
+const breadcrumbSchema = {
+	'@context': 'https://schema.org',
+	'@type': 'BreadcrumbList',
+	'@id': `${canonicalUrl}#breadcrumb`,
+	itemListElement: [
+		{ '@type': 'ListItem', position: 1, name: 'Home', item: `${siteOrigin}/` },
+		{ '@type': 'ListItem', position: 2, name: 'Farm Calculator', item: canonicalUrl },
+	],
+};
+const structuredData = [breadcrumbSchema];
+---
+
+<Layout {title} {description} slug="farm" structuredData={structuredData}>
+	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
+	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Farm Calculator</h1>
+	<p class="mx-auto mb-8 max-w-3xl text-center text-sky-200/90">
+		Select growable plants and set plot counts to estimate harvest cycle time and total yield per crop.
+	</p>
+
+	<div class="mx-auto max-w-5xl px-4 mb-8">
+		<label for="plant-select" class="mb-2 block text-sm font-semibold text-sky-300">Add a plant</label>
+		<div class="flex flex-wrap gap-3">
+			<select
+				id="plant-select"
+				class="h-10 min-w-[16rem] flex-1 rounded-sm border border-sky-700 bg-sky-900/50 px-3 text-white focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+			>
+				<option value="">Choose a plant…</option>
+				{
+					plants.map((plant) => (
+						<option value={plant.harvestId}>
+							{plant.name} ({plant.growTime})
+						</option>
+					))
+				}
+			</select>
+			<button
+				id="add-plant-btn"
+				type="button"
+				class="h-10 rounded-sm bg-sky-600 px-4 font-semibold text-white transition-colors hover:bg-sky-500"
+			>
+				Add plant
+			</button>
+		</div>
+	</div>
+
+	<div id="empty-selection" class="mx-auto max-w-5xl px-4 py-8 text-center text-sky-400">
+		No plants selected yet. Add a crop above to start planning.
+	</div>
+
+	<div id="farm-results" class="mx-auto hidden max-w-5xl px-4 pb-12">
+		<div class="mb-6 grid gap-4 sm:grid-cols-2">
+			<div class="rounded-sm border border-sky-800/70 bg-sky-950/40 p-4">
+				<p class="m-0 text-sm uppercase tracking-wide text-sky-400">Full harvest cycle</p>
+				<p id="cycle-time" class="m-0 mt-1 text-2xl font-semibold text-white"></p>
+				<p class="m-0 mt-1 text-sm text-sky-300">Longest grow time among selected plants</p>
+			</div>
+			<div class="rounded-sm border border-sky-800/70 bg-sky-950/40 p-4">
+				<p class="m-0 text-sm uppercase tracking-wide text-sky-400">Total plots</p>
+				<p id="total-plots" class="m-0 mt-1 text-2xl font-semibold text-white"></p>
+				<p class="m-0 mt-1 text-sm text-sky-300">Combined plant count across all crops</p>
+			</div>
+		</div>
+
+		<div class="overflow-x-auto rounded-sm border border-sky-800/70 bg-sky-950/40">
+			<table class="min-w-full border-collapse text-sm">
+				<thead>
+					<tr class="bg-sky-600/90 text-left uppercase tracking-wide text-white">
+						<th class="px-4 py-3">Plant</th>
+						<th class="px-4 py-3">Grow time</th>
+						<th class="px-4 py-3">Plots</th>
+						<th class="px-4 py-3">Yield / harvest</th>
+						<th class="px-4 py-3">Total yield</th>
+						<th class="px-4 py-3"></th>
+					</tr>
+				</thead>
+				<tbody id="selected-plants-body"></tbody>
+			</table>
+		</div>
+	</div>
+</Layout>
+
+<script define:vars={{ IMAGE_BASE, plants }}>
+	const plantById = new Map(plants.map((plant) => [plant.harvestId, plant]));
+	const selected = new Map();
+
+	const plantSelect = document.getElementById('plant-select');
+	const addBtn = document.getElementById('add-plant-btn');
+	const emptyEl = document.getElementById('empty-selection');
+	const resultsEl = document.getElementById('farm-results');
+	const tbody = document.getElementById('selected-plants-body');
+	const cycleTimeEl = document.getElementById('cycle-time');
+	const totalPlotsEl = document.getElementById('total-plots');
+
+	function escapeHtml(str) {
+		if (str == null) return '';
+		const s = String(str);
+		return s
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
+
+	function formatMinutes(minutes) {
+		const hours = Math.floor(minutes / 60);
+		const mins = minutes % 60;
+		if (hours && mins) {
+			return `${hours} hour${hours !== 1 ? 's' : ''} ${mins} minute${mins !== 1 ? 's' : ''}`;
+		}
+		if (hours) {
+			return `${hours} hour${hours !== 1 ? 's' : ''}`;
+		}
+		return `${mins} minute${mins !== 1 ? 's' : ''}`;
+	}
+
+	function render() {
+		if (!tbody || !emptyEl || !resultsEl || !cycleTimeEl || !totalPlotsEl) return;
+
+		if (selected.size === 0) {
+			emptyEl.classList.remove('hidden');
+			resultsEl.classList.add('hidden');
+			tbody.innerHTML = '';
+			return;
+		}
+
+		emptyEl.classList.add('hidden');
+		resultsEl.classList.remove('hidden');
+
+		let maxMinutes = 0;
+		let totalPlots = 0;
+		const rows = [];
+
+		for (const [harvestId, count] of selected.entries()) {
+			const plant = plantById.get(harvestId);
+			if (!plant) continue;
+			maxMinutes = Math.max(maxMinutes, plant.growTimeMinutes);
+			totalPlots += count;
+			const totalYield = count * plant.harvestQuantity;
+			rows.push(`
+				<tr class="border-t border-sky-800/60" data-harvest-id="${escapeHtml(harvestId)}">
+					<td class="px-4 py-3">
+						<div class="flex items-center gap-3">
+							<img
+								src="${IMAGE_BASE}${escapeHtml(plant.icon)}"
+								alt="${escapeHtml(plant.name)}"
+								class="h-10 w-10 object-contain"
+								loading="lazy"
+								width="40"
+								height="40"
+							/>
+							<span class="font-semibold text-white">${escapeHtml(plant.name)}</span>
+						</div>
+					</td>
+					<td class="px-4 py-3 text-sky-200">${escapeHtml(plant.growTime)}</td>
+					<td class="px-4 py-3">
+						<input
+							type="number"
+							min="1"
+							value="${count}"
+							class="plot-count h-9 w-20 rounded-sm border border-sky-700 bg-sky-900/50 px-2 text-white"
+							aria-label="Plot count for ${escapeHtml(plant.name)}"
+						/>
+					</td>
+					<td class="px-4 py-3 text-sky-200">${plant.harvestQuantity.toLocaleString()}</td>
+					<td class="px-4 py-3 font-semibold text-lime-300">${totalYield.toLocaleString()}</td>
+					<td class="px-4 py-3">
+						<button
+							type="button"
+							class="remove-plant rounded-sm border border-sky-600 px-2 py-1 text-xs text-sky-400 hover:bg-sky-900/50 hover:text-white"
+						>
+							Remove
+						</button>
+					</td>
+				</tr>
+			`);
+		}
+
+		tbody.innerHTML = rows.join('');
+		cycleTimeEl.textContent = maxMinutes > 0 ? formatMinutes(maxMinutes) : '—';
+		totalPlotsEl.textContent = totalPlots.toLocaleString();
+
+		tbody.querySelectorAll('.plot-count').forEach((input) => {
+			input.addEventListener('change', (event) => {
+				const target = event.currentTarget;
+				const row = target.closest('tr');
+				const harvestId = row?.dataset.harvestId;
+				if (!harvestId) return;
+				const value = Math.max(1, Number.parseInt(target.value, 10) || 1);
+				target.value = String(value);
+				selected.set(harvestId, value);
+				render();
+			});
+		});
+
+		tbody.querySelectorAll('.remove-plant').forEach((button) => {
+			button.addEventListener('click', (event) => {
+				const row = event.currentTarget.closest('tr');
+				const harvestId = row?.dataset.harvestId;
+				if (!harvestId) return;
+				selected.delete(harvestId);
+				render();
+			});
+		});
+	}
+
+	addBtn?.addEventListener('click', () => {
+		const harvestId = plantSelect?.value;
+		if (!harvestId || !plantById.has(harvestId)) return;
+		if (!selected.has(harvestId)) {
+			selected.set(harvestId, 1);
+		}
+		render();
+	});
+</script>

--- a/src/pages/fish/[page].astro
+++ b/src/pages/fish/[page].astro
@@ -4,7 +4,7 @@ import CompactCard from '@components/CompactCard.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Fish.json';
 import Pagination from '@components/Pagination.astro';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of fish for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Fish', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Fish', baseDescription, page.
 	{description}
 	slug="fish"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Fish</h1>

--- a/src/pages/fish/index.astro
+++ b/src/pages/fish/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Fish.json';
-import Pagination from '@components/Pagination.astro';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of fish for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Fish', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,24 +53,10 @@ const { title, description } = buildPaginatedMeta('Fish', baseDescription, page.
 	{description}
 	slug="fish"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Fish</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-
-	<Pagination page={page} />
+	<CategoryFilter type="fish" basePath="/fish" />
 </Layout>

--- a/src/pages/food/[page].astro
+++ b/src/pages/food/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Food.json';
 import { SITE } from '@config';
@@ -53,6 +53,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of food items for No Man's Sky. Browse all edible products and ingredients.";
 const { title, description } = buildPaginatedMeta('Food', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -60,6 +61,8 @@ const { title, description } = buildPaginatedMeta('Food', baseDescription, page.
 	{description}
 	slug="food"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Food</h1>

--- a/src/pages/food/index.astro
+++ b/src/pages/food/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Food.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedFood = sort(data as Item[]);
@@ -48,6 +46,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of food items for No Man's Sky. Browse all edible products and ingredients.";
 const { title, description } = buildPaginatedMeta('Food', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -55,23 +54,10 @@ const { title, description } = buildPaginatedMeta('Food', baseDescription, page.
 	{description}
 	slug="food"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Food</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="food" basePath="/food" />
 </Layout>

--- a/src/pages/other/[page].astro
+++ b/src/pages/other/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import others from '@datav2/Others.json';
 import trade from '@datav2/Trade.json';
@@ -52,6 +52,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of other items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Other Items', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -59,6 +60,8 @@ const { title, description } = buildPaginatedMeta('Other Items', baseDescription
 	{description}
 	slug="other"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Other Items</h1>

--- a/src/pages/other/index.astro
+++ b/src/pages/other/index.astro
@@ -1,15 +1,13 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import others from '@datav2/Others.json';
 import trade from '@datav2/Trade.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort([...others, ...trade] as Item[]);
@@ -48,6 +46,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of other items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Other Items', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -55,23 +54,10 @@ const { title, description } = buildPaginatedMeta('Other Items', baseDescription
 	{description}
 	slug="other"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Other Items</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: `${SITE.imageBaseUrl}${item.Icon}`,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="other" basePath="/other" />
 </Layout>

--- a/src/pages/products/[page].astro
+++ b/src/pages/products/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Products.json';
 import { SITE } from '@config';
@@ -52,6 +52,7 @@ const intro = buildCategoryIntro(
 	page.lastPage
 );
 const { title, description } = buildPaginatedMeta('Products', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -59,6 +60,8 @@ const { title, description } = buildPaginatedMeta('Products', baseDescription, p
 	{description}
 	slug="products"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Products</h1>

--- a/src/pages/products/index.astro
+++ b/src/pages/products/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Products.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -49,6 +47,7 @@ const intro = buildCategoryIntro(
 const baseDescription =
 	"Browse No Man's Sky products with crafting ingredients, trade value, and advanced manufacturing chains.";
 const { title, description } = buildPaginatedMeta('Products', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -56,23 +55,10 @@ const { title, description } = buildPaginatedMeta('Products', baseDescription, p
 	{description}
 	slug="products"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Products</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="products" basePath="/products" />
 </Layout>

--- a/src/pages/raw/[page].astro
+++ b/src/pages/raw/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/RawMaterials.json';
 import { SITE } from '@config';
@@ -52,6 +52,7 @@ const intro = buildCategoryIntro(
 	page.lastPage
 );
 const { title, description } = buildPaginatedMeta('Raw Materials', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -59,6 +60,8 @@ const { title, description } = buildPaginatedMeta('Raw Materials', baseDescripti
 	{description}
 	slug="raw"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Raw Materials</h1>

--- a/src/pages/raw/index.astro
+++ b/src/pages/raw/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/RawMaterials.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "Browse No Man's Sky raw materials, foundational resources, and ingredient pages for crafting, refining, cooking, and upgrade chains.";
 const { title, description } = buildPaginatedMeta('Raw Materials', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Raw Materials', baseDescripti
 	{description}
 	slug="raw"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Raw Materials</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="raw" basePath="/raw" />
 </Layout>

--- a/src/pages/refining/index.astro
+++ b/src/pages/refining/index.astro
@@ -3,9 +3,10 @@
 import Layout from '@layouts/Layout.astro';
 import Table from '@components/table/Table.astro';
 import refinery from '@datav2/Refinery.json';
-import { getById } from '@utils/lookup.js';
+import { getById, getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import type { TableRow } from '@components/table/Table.astro';
+import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
 import { SITE } from '@config';
 
 // Interfaces for defining the shape of input and output objects
@@ -105,13 +106,36 @@ const columns = [
 
 // Use type assertion for better type inference
 const data = refinery.map(createArray).filter((item): item is TableItem => item !== undefined);
+
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/refining', siteOrigin).toString();
+const baseDescription =
+	"Browse No Man's Sky refiner recipes, ingredient combinations, and outputs. Use this refiner guide to discover the best refining chains for units and crafting.";
+const itemListElements = data.slice(0, 25).map((row, index) => {
+	const outputItem = getById(row.output.id);
+	return {
+		name: row.output.name,
+		url: outputItem ? `${siteOrigin}${getSlug(outputItem)}` : canonicalUrl,
+		position: index + 1,
+	};
+});
+const structuredData = buildCollectionStructuredData({
+	siteOrigin,
+	canonicalUrl,
+	collectionName: 'Refiner recipes',
+	collectionDescription: baseDescription,
+	collectionPath: '/refining',
+	currentPage: 1,
+	items: itemListElements,
+});
 ---
 
 <Layout
 	title={"Refiner recipes | No Man's Sky Recipes"}
-	description="Browse No Man's Sky refiner recipes, ingredient combinations, and outputs. Use this refiner guide to discover the best refining chains for units and crafting."
+	description={baseDescription}
 	slug="refining"
 	ogImage={`${SITE.website}/images/refiner.webp`}
+	structuredData={structuredData}
 >
 	<Table
 		title="Refining"

--- a/src/pages/starships/[page].astro
+++ b/src/pages/starships/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Starships.json';
 import { SITE } from '@config';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of starship items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Starships', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Starships', baseDescription, 
 	{description}
 	slug="starships"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Starships</h1>

--- a/src/pages/starships/index.astro
+++ b/src/pages/starships/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Starships.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of starship items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Starships', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Starships', baseDescription, 
 	{description}
 	slug="starships"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Starships</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="starships" basePath="/starships" />
 </Layout>

--- a/src/pages/technology/[page].astro
+++ b/src/pages/technology/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import conTech from '@datav2/ConstructedTechnology.json';
 import techModule from '@datav2/TechnologyModule.json';
@@ -53,6 +53,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of technology items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Technology Items', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -60,6 +61,8 @@ const { title, description } = buildPaginatedMeta('Technology Items', baseDescri
 	{description}
 	slug="technology"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Technology</h1>

--- a/src/pages/technology/index.astro
+++ b/src/pages/technology/index.astro
@@ -1,16 +1,14 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import conTech from '@datav2/ConstructedTechnology.json';
 import techModule from '@datav2/TechnologyModule.json';
 import tech from '@datav2/Technology.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort([...conTech, ...tech, ...techModule] as Item[]);
@@ -49,6 +47,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of technology items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Technology Items', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -56,23 +55,10 @@ const { title, description } = buildPaginatedMeta('Technology Items', baseDescri
 	{description}
 	slug="technology"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Technology</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="technology" basePath="/technology" />
 </Layout>

--- a/src/pages/upgrades/[page].astro
+++ b/src/pages/upgrades/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Upgrades.json';
 import { SITE } from '@config';
@@ -51,6 +51,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of upgrade items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Upgrades', baseDescription, page.currentPage, page.lastPage);
+const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -58,6 +59,8 @@ const { title, description } = buildPaginatedMeta('Upgrades', baseDescription, p
 	{description}
 	slug="upgrades"
 	structuredData={structuredData}
+	prevUrl={prevUrl}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Upgrades</h1>

--- a/src/pages/upgrades/index.astro
+++ b/src/pages/upgrades/index.astro
@@ -1,14 +1,12 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import CompactCard from '@components/CompactCard.astro';
-import Pagination from '@components/Pagination.astro';
+import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import data from '@datav2/Upgrades.json';
-import { SITE } from '@config';
 
 const pageSize = 80;
 const sortedItems = sort(data as Item[]);
@@ -47,6 +45,7 @@ const intro = buildCategoryIntro(
 );
 const baseDescription = "A list of upgrade items for No Man's Sky. Our guide has everything you need to take your game to the next level.";
 const { title, description } = buildPaginatedMeta('Upgrades', baseDescription, page.currentPage, page.lastPage);
+const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
 <Layout
@@ -54,23 +53,10 @@ const { title, description } = buildPaginatedMeta('Upgrades', baseDescription, p
 	{description}
 	slug="upgrades"
 	structuredData={structuredData}
+	nextUrl={nextUrl}
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Upgrades</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-		{
-			page.data.map((item, index) => (
-				<CompactCard
-					card={{
-						name: item.Name,
-						image: SITE.imageBaseUrl + item.Icon,
-						link: getSlug(item),
-					}}
-					index={index}
-				/>
-			))
-		}
-	</div>
-	<Pagination page={page} />
+	<CategoryFilter type="upgrades" basePath="/upgrades" />
 </Layout>

--- a/src/utils/plantGrowTime.ts
+++ b/src/utils/plantGrowTime.ts
@@ -1,5 +1,6 @@
 import products from '../datav2/Products.json';
 import localization from '../datav2/localization.json';
+import { getById } from './lookup';
 import type { Item } from './lookup';
 
 const GROW_TIME_RE = /Approximate growing time:\s*(.+)/;
@@ -55,6 +56,69 @@ function buildPlantGrowTimeLookup(): Record<string, string> {
 }
 
 const plantGrowTimeByHarvestId = buildPlantGrowTimeLookup();
+
+export type GrowablePlant = {
+	harvestId: string;
+	seedId: string;
+	name: string;
+	icon: string;
+	growTime: string;
+	growTimeMinutes: number;
+	harvestQuantity: number;
+};
+
+export function parseGrowTimeMinutes(growTime: string): number {
+	const normalized = growTime.toLowerCase().trim();
+	let total = 0;
+	const hourMatch = normalized.match(/(\d+)\s*(?:hour|hours|hr|hrs)\b/);
+	if (hourMatch) {
+		total += Number.parseInt(hourMatch[1], 10) * 60;
+	}
+	const minMatch = normalized.match(/(\d+)\s*(?:min|mins|minute|minutes)\b/);
+	if (minMatch) {
+		total += Number.parseInt(minMatch[1], 10);
+	}
+	return total;
+}
+
+function resolveHarvestQuantity(seed: Item, harvestId: string): number {
+	const harvestEntry = seed.RequiredItems?.find((item) => item.Id === harvestId);
+	return harvestEntry?.Quantity ?? 1;
+}
+
+export function getAllGrowablePlants(): GrowablePlant[] {
+	const plants: GrowablePlant[] = [];
+
+	for (const product of products as Item[]) {
+		let growTime = parseGrowTime(product.Description ?? '');
+
+		if (!growTime && product.Id === 'NIPPLANT') {
+			growTime = parseGrowTime(localizationStrings.UI_PLANTPROD_NIP_DESC ?? '');
+		}
+
+		if (!growTime) {
+			continue;
+		}
+
+		const harvestId = resolveHarvestId(product);
+		if (!harvestId) {
+			continue;
+		}
+
+		const harvestItem = getById(harvestId);
+		plants.push({
+			harvestId,
+			seedId: product.Id,
+			name: harvestItem?.Name ?? harvestId,
+			icon: harvestItem?.Icon ?? product.Icon,
+			growTime,
+			growTimeMinutes: parseGrowTimeMinutes(growTime),
+			harvestQuantity: resolveHarvestQuantity(product, harvestId),
+		});
+	}
+
+	return plants.sort((a, b) => a.name.localeCompare(b.name));
+}
 
 export function getPlantGrowTime(itemId: string): string | undefined {
 	return plantGrowTimeByHarvestId[itemId];

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -255,3 +255,19 @@ export const buildPaginatedMeta = (
 			: baseDescription;
 	return { title, description };
 };
+
+const normalizePrevHref = (href?: string): string | undefined => {
+	if (!href) return href;
+	const normalized = href.replace(/\/1\/?$/, '');
+	return normalized === '' ? '/' : normalized;
+};
+
+export const buildPaginationUrls = (
+	siteOrigin: string,
+	page: { url: { prev?: string; next?: string } }
+): { prevUrl?: string; nextUrl?: string } => {
+	const prevHref = normalizePrevHref(page.url.prev);
+	const prevUrl = prevHref ? new URL(prevHref, siteOrigin).toString() : undefined;
+	const nextUrl = page.url.next ? new URL(page.url.next, siteOrigin).toString() : undefined;
+	return { prevUrl, nextUrl };
+};


### PR DESCRIPTION
## Summary
Implements 5 items from the site review (REVIEW.md) in one batch: the discovery-UX and SEO cluster the user selected (#4, #10, #20, #35, #37). Built by Cursor CLI, **independently verified** in the browser — which caught and fixed two bugs that compiled and built clean but were functionally broken (see below).

## What's included
- **#4 — Search & filters on category grid pages.** New reusable `CategoryFilter.astro` brings the `/items`-style filtering (group combobox + name search + infinite scroll, URL-synced) to all 12 category index pages (`/products`, `/fish`, `/buildings`, `/upgrades`, etc.). Scoped per-category by URL prefix so it works on the static build. The paginated `[page].astro` routes are untouched and remain the crawlable fallback.
- **#10 — Structured data on recipe hubs.** `BreadcrumbList` + `CollectionPage`/`ItemList` JSON-LD added to `/refining`, `/cooking`, `/crafting-guide` (first 25 outputs with canonical URLs).
- **#20 — Affinity chart ↔ species cross-linking.** All 8 affinity cards and every matchup table cell link to `/creatures/species?affinity=<DisplayName>`. Species page reads the param, filters the Tabulator table, shows a clearable chip, and links back to the affinity guide.
- **#35 — Sitemap & pagination SEO polish.** Sitemap `lastmod` is now a stable `SITE.version_date` (was a fresh `new Date()` every build, which churned crawl cache); `rel="prev"`/`rel="next"` added to paginated category pages; `/creatures/species/<id>` detail pages are no longer excluded from the sitemap.
- **#37 — Farm / grow-time calculator.** New `/farm` route: pick growable plants, set plot counts, see full harvest-cycle time (longest grow) and total yield. Extends `plantGrowTime.ts` with `getAllGrowablePlants()` + minute parsing. Added to the sidebar.

## Verification (independent, not self-reported)
- `pnpm run type-check` — pass
- `pnpm run build` — pass, **5094 pages** (+1 for `/farm`)
- `pnpm run lint` — clean except the known **pre-existing** `no-useless-escape` in `src/pages/index.astro` (byte-identical to `main`, left untouched)
- Browser-verified each feature on a production `preview` build:
  - `/fish` now shows only fish (226), not all 4,822 items
  - `?affinity=Tropical` returns exactly the 10 Tropical species; Clear restores all 84
  - farm calculator computes cycle time + yield
  - hub JSON-LD present in built HTML; sitemap lastmod single stable date; rel prev/next chains correctly

## Two bugs caught in review (and fixed)
1. **Category filters showed all items.** Initial implementation relied on `/items.json?type=` server-side filtering, but this is a **static build** — the query param is ignored, so every category page rendered all 4,822 items. Fixed with a client-side URL-prefix type filter + type-scoped group dropdown.
2. **Affinity filter matched nothing.** Tabulator's HTML import stores each cell's **innerHTML**, so the affinity value was the raw HTML string, not `"Tropical"` — the exact-match filter never hit. Fixed by stripping HTML tags before tokenizing the affinity value.

## Notes / minor caveats
- Category index pages are JS-driven grids (same established pattern as `/items`); the `[page].astro` routes stay as the static crawlable fallback.
- Farm calculator covers the plants with parseable grow times from game data.

Deferred to the Hard bucket per the plan: #1, #11, #21, #32, #36, #38, #40.