### PR TITLE
feat(search): recipe-ingredient search + relevance ranking + result polish (REVIEW #38)

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -89,6 +89,16 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		}, {});
 	}
 
+	function getSearchRelevanceRank(name, searchText, searchTerm) {
+		const lowerName = name.toLowerCase();
+		if (lowerName === searchTerm) return 0;
+		if (lowerName.startsWith(searchTerm)) return 1;
+		if (lowerName.includes(searchTerm)) return 2;
+		const extra = typeof searchText === 'string' ? searchText.toLowerCase() : '';
+		if (extra.includes(searchTerm)) return 3;
+		return 4;
+	}
+
 	async function loadSearchDataset() {
 		if (!searchDatasetPromise) {
 			searchDatasetPromise = fetch('/search.json', { cache: 'force-cache' })
@@ -134,6 +144,12 @@ const imageBaseUrl = SITE.imageBaseUrl;
 					const extra =
 						typeof result.searchText === 'string' ? result.searchText.toLowerCase() : '';
 					return nameMatch || extra.includes(searchTerm);
+				})
+				.sort((a, b) => {
+					const rankA = getSearchRelevanceRank(a.name, a.searchText, searchTerm);
+					const rankB = getSearchRelevanceRank(b.name, b.searchText, searchTerm);
+					if (rankA !== rankB) return rankA - rankB;
+					return a.name.localeCompare(b.name);
 				})
 				.slice(0, MAX_RESULTS);
 			const groupedResults = groupBy(filteredResults, 'type');
@@ -233,7 +249,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 						const img = document.createElement('img');
 						img.src = `${imageBaseUrl}${result.icon}`;
 						img.alt = '';
-						img.className = 'h-6 w-6 shrink-0';
+						img.className = 'h-6 w-6 shrink-0 object-contain self-center';
 						img.loading = 'lazy';
 						a.appendChild(img);
 					}
@@ -241,12 +257,6 @@ const imageBaseUrl = SITE.imageBaseUrl;
 					const nameSpan = document.createElement('span');
 					nameSpan.textContent = result.name;
 					a.appendChild(nameSpan);
-
-					const badge = document.createElement('span');
-					badge.className =
-						'ml-auto shrink-0 rounded-sm bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300';
-					badge.textContent = filterLabelMap[result.type] || result.type;
-					a.appendChild(badge);
 
 					li.appendChild(a);
 					ul.appendChild(li);

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -4,6 +4,47 @@ import { getSlug, sort } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import * as dataSources from '@datav2/index.js';
 
+type RecipeForSearch = {
+	Inputs?: { Name?: string | null }[];
+	Output?: { Id?: string; Name?: string | null } | null;
+	Operation?: string | null;
+};
+
+function buildRecipeSearchTokensByOutputId(
+	recipes: RecipeForSearch[]
+): Map<string, Set<string>> {
+	const map = new Map<string, Set<string>>();
+
+	for (const recipe of recipes) {
+		const outputId = recipe.Output?.Id;
+		if (!outputId) continue;
+
+		let tokens = map.get(outputId);
+		if (!tokens) {
+			tokens = new Set();
+			map.set(outputId, tokens);
+		}
+
+		for (const input of recipe.Inputs ?? []) {
+			const name = input.Name?.trim();
+			if (name) tokens.add(name);
+		}
+
+		const outputName = recipe.Output?.Name?.trim();
+		if (outputName) tokens.add(outputName);
+
+		const operation = recipe.Operation?.trim();
+		if (operation) tokens.add(operation);
+	}
+
+	return map;
+}
+
+const recipeSearchTokensByOutputId = buildRecipeSearchTokensByOutputId([
+	...(dataSources.Refinery as RecipeForSearch[]),
+	...(dataSources.NutrientProcessor as RecipeForSearch[]),
+]);
+
 type SearchIndexEntry = {
 	id: string;
 	name: string;
@@ -40,13 +81,24 @@ const itemSearchEntries: SearchIndexEntry[] = data
 	.filter((item: Item) => item?.Name != null && String(item.Name).trim() !== '')
 	.map((item: Item) => {
 		const url = getSlug(item);
-		return {
+		const entry: SearchIndexEntry = {
 			id: item.Id,
 			name: item.Name,
 			type: getTypeFromUrl(url),
 			url,
 			icon: item.Icon,
 		};
+
+		const recipeTokens = recipeSearchTokensByOutputId.get(item.Id);
+		if (recipeTokens && recipeTokens.size > 0) {
+			const parts = [
+				...(entry.searchText ? [entry.searchText] : []),
+				...recipeTokens,
+			];
+			entry.searchText = parts.join('\n');
+		}
+
+		return entry;
 	});
 
 const blogPosts: CollectionEntry<'blog'>[] = await getCollection('blog');


### PR DESCRIPTION
Implements REVIEW.md #38 (Approach A — ingredient/output text match) plus search-result UX follow-ups.

## What
- **Recipe-as-query search** (`search.json.ts`): build-time enriches each output item's `searchText` with its refiner/nutrient recipe **input names + output name + operation**, so searching an ingredient surfaces the product. Covers both Refinery (358) + NutrientProcessor (1323). Pure additive — 403 items enriched, 4,419 unchanged, blog descriptions preserved. No SSR, no UI/schema change.
- **Relevance ranking** (`SearchModal.astro`): rank matches exact-name → name-prefix → name-contains → recipe/searchText-only, alphabetical within each tier, sorted **before** the MAX_RESULTS cap. Fixes 'oxygen' listing Cactus Flesh above the literal Oxygen item.
- **Result polish:** removed the grey category badge; vertically centered result icons (`object-contain self-center`).

## Verified independently
- type-check ✓, lint ✓ (only the pre-existing `index.astro` no-useless-escape remains, untouched), build ✓ 5,094 pages.
- Live browser test on `astro preview`: 'oxygen' → **Oxygen** first, then recipe matches (Carbon, Cactus Flesh…); 'fermentation' → Wild Yeast; 0 badges; icons centered.
- Data baseline confirmed: Carbon (FUEL1) ← Oxygen/Condensed Carbon/Fungal Mould/etc.