### PR TITLE
feat(calculator): multi-item Crafting Planner + Reverse Calculator (REVIEW #1, #36)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,6 +32,9 @@ const shouldIncludeInSitemap = (page) => {
 // https://astro.build/config
 export default defineConfig({
   site: "https://nomansskyrecipes.com",
+  redirects: {
+    '/farm': '/calculator/farm',
+  },
   integrations: [
     sitemap({
       filter: shouldIncludeInSitemap,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@typescript-eslint/parser": "^8.60.1",
 		"eslint": "^10.4.1",
 		"eslint-plugin-astro": "^1.7.0",
+		"playwright": "1.60.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.60.1"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-plugin-astro:
         specifier: ^1.7.0
         version: 1.7.0(eslint@10.4.1(jiti@2.7.0))
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1283,6 +1286,11 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1775,6 +1783,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -3351,6 +3369,9 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4025,6 +4046,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/src/layouts/Sidebar.astro
+++ b/src/layouts/Sidebar.astro
@@ -30,7 +30,12 @@ const toolsNav: NavItem[] = [
 	{ name: 'Refining', href: '/refining', icon: 'funnel' },
 	{ name: 'Cooking', href: '/cooking', icon: 'beaker' },
 	{ name: 'Crafting', href: '/crafting-guide', icon: 'wrench-screwdriver' },
+];
+
+const calculatorsNav: NavItem[] = [
 	{ name: 'Calculator', href: '/calculator', icon: 'calculator' },
+	{ name: 'Crafting Planner', href: '/calculator/planner', icon: 'archive-box' },
+	{ name: 'Reverse Calculator', href: '/calculator/reverse', icon: 'scale' },
 	{ name: 'Farm Calculator', href: '/farm', icon: 'sun' },
 ];
 
@@ -57,6 +62,7 @@ const moreNav: NavItem[] = [
 	{ name: 'Feedback', href: '/feedback', icon: 'envelope' },
 ];
 
+const isCalculatorsActive = calculatorsNav.some((item) => isNavItemActive(item.href));
 const isCatalogActive = catalogsNav.some((item) => isNavItemActive(item.href));
 
 const icons: Record<string, IconPath[]> = {
@@ -295,10 +301,86 @@ const sectionLabelClasses =
 							})
 						}
 
+						<p id="nav-calculators-label-mobile" class={sectionLabelClasses}>Calculators</p>
+						<div>
+							<button
+								data-accordion-btn="calculators"
+								type="button"
+								class={classNames(
+									linkClasses(isCalculatorsActive),
+									'w-full justify-between',
+								)}
+								aria-expanded={isCalculatorsActive ? 'true' : 'false'}
+								aria-controls="calculators-accordion-panel"
+							>
+								<span class="flex items-center">
+									<svg
+										class={iconClasses(isCalculatorsActive)}
+										viewBox="0 0 24 24"
+										fill="currentColor"
+										aria-hidden="true"
+									>
+										{icons.calculator.map((path) => (
+											<path d={path.d} fill-rule={path.fillRule} clip-rule={path.clipRule} />
+										))}
+									</svg>
+									Calculators
+								</span>
+								<svg
+									class={classNames(
+										isCalculatorsActive ? 'text-black' : 'text-gray-400',
+										'h-4 w-4 shrink-0 transition-transform',
+										isCalculatorsActive ? 'rotate-180' : '',
+									)}
+									data-accordion-chevron="calculators"
+									viewBox="0 0 24 24"
+									fill="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										fill-rule="evenodd"
+										d="M12.53 16.28a.75.75 0 0 1-1.06 0l-7.5-7.5a.75.75 0 0 1 1.06-1.06L12 14.69l6.97-6.97a.75.75 0 1 1 1.06 1.06l-7.5 7.5Z"
+										clip-rule="evenodd"></path>
+								</svg>
+							</button>
+							<div
+								id="calculators-accordion-panel"
+								data-accordion-panel="calculators"
+								class={classNames('mt-1 space-y-1 pl-2', isCalculatorsActive ? '' : 'hidden')}
+								role="region"
+								aria-labelledby="nav-calculators-label-mobile"
+							>
+								{
+									calculatorsNav.map((item) => {
+										const active = isNavItemActive(item.href);
+										return (
+											<a href={item.href} class={linkClasses(active)}>
+												<svg
+													class={iconClasses(active)}
+													viewBox="0 0 24 24"
+													fill="currentColor"
+													aria-hidden="true"
+												>
+													{icons[item.icon].map((path) => (
+														<path
+															d={path.d}
+															fill-rule={path.fillRule}
+															clip-rule={path.clipRule}
+														/>
+													))}
+												</svg>
+												{item.name}
+											</a>
+										);
+									})
+								}
+							</div>
+						</div>
+
 						<p id="nav-catalogs-label-mobile" class={sectionLabelClasses}>Catalogs</p>
 						<div>
 							<button
-								id="catalogs-accordion-btn"
+								data-accordion-btn="catalogs"
 								type="button"
 								class={classNames(
 									linkClasses(isCatalogActive),
@@ -327,6 +409,7 @@ const sectionLabelClasses =
 										isCatalogActive ? 'rotate-180' : '',
 									)}
 									id="catalogs-accordion-chevron"
+									data-accordion-chevron="catalogs"
 									viewBox="0 0 24 24"
 									fill="currentColor"
 									aria-hidden="true"
@@ -339,6 +422,7 @@ const sectionLabelClasses =
 							</button>
 							<div
 								id="catalogs-accordion-panel"
+								data-accordion-panel="catalogs"
 								class={classNames('mt-1 space-y-1 pl-2', isCatalogActive ? '' : 'hidden')}
 								role="region"
 								aria-labelledby="nav-catalogs-label-mobile"
@@ -426,9 +510,47 @@ const sectionLabelClasses =
 						})
 					}
 
+					<p id="nav-calculators-label" class={sectionLabelClasses}>Calculators</p>
+					<button
+						data-flyout-trigger="calculators"
+						type="button"
+						class={classNames(linkClasses(isCalculatorsActive), 'w-full justify-between')}
+						aria-expanded="false"
+						aria-haspopup="true"
+						aria-controls="calculators-flyout"
+					>
+						<span class="flex items-center">
+							<svg
+								class={iconClasses(isCalculatorsActive)}
+								viewBox="0 0 24 24"
+								fill="currentColor"
+								aria-hidden="true"
+							>
+								{icons.calculator.map((path) => (
+									<path d={path.d} fill-rule={path.fillRule} clip-rule={path.clipRule} />
+								))}
+							</svg>
+							Calculators
+						</span>
+						<svg
+							class={classNames(
+								isCalculatorsActive ? 'text-black' : 'text-gray-400',
+								'h-4 w-4 shrink-0',
+							)}
+							viewBox="0 0 24 24"
+							fill="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								fill-rule="evenodd"
+								d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z"
+								clip-rule="evenodd"></path>
+						</svg>
+					</button>
+
 					<p id="nav-catalogs-label" class={sectionLabelClasses}>Catalogs</p>
 					<button
-						id="catalogs-flyout-trigger"
+						data-flyout-trigger="catalogs"
 						type="button"
 						class={classNames(linkClasses(isCatalogActive), 'w-full justify-between')}
 						aria-expanded="false"
@@ -485,12 +607,48 @@ const sectionLabelClasses =
 		</div>
 	</div>
 
+	<!-- Desktop calculators flyout (outside overflow container) -->
+	<div
+		id="calculators-flyout"
+		data-flyout="calculators"
+		class="fixed z-50 hidden pl-3"
+		role="menu"
+		aria-labelledby="nav-calculators-label"
+	>
+		<div
+			class="max-h-[calc(100vh-2rem)] overflow-y-auto rounded-md border border-white/10 bg-black p-2 shadow-lg"
+		>
+			<div class="grid grid-cols-1 gap-0.5 sm:grid-cols-2">
+				{
+					calculatorsNav.map((item) => {
+						const active = isNavItemActive(item.href);
+						return (
+							<a
+								href={item.href}
+								role="menuitem"
+								class={linkClasses(active)}
+							>
+								<svg class={iconClasses(active)} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+									{icons[item.icon].map((path) => (
+										<path d={path.d} fill-rule={path.fillRule} clip-rule={path.clipRule} />
+									))}
+								</svg>
+								{item.name}
+							</a>
+						);
+					})
+				}
+			</div>
+		</div>
+	</div>
+
 	<!-- Desktop catalogs flyout (outside overflow container) -->
 	<div
 		id="catalogs-flyout"
+		data-flyout="catalogs"
 		class="fixed z-50 hidden pl-3"
 		role="menu"
-		aria-labelledby="catalogs-flyout-trigger"
+		aria-labelledby="nav-catalogs-label"
 	>
 		<div
 			class="max-h-[calc(100vh-2rem)] overflow-y-auto rounded-md border border-white/10 bg-black p-2 shadow-lg"
@@ -581,120 +739,144 @@ const sectionLabelClasses =
 	sidebarCloseBtn?.addEventListener('click', closeMobileDrawer);
 	mobileBackdrop?.addEventListener('click', closeMobileDrawer);
 
-	// Mobile catalogs accordion
-	const accordionBtn = document.getElementById('catalogs-accordion-btn');
-	const accordionPanel = document.getElementById('catalogs-accordion-panel');
-	const accordionChevron = document.getElementById('catalogs-accordion-chevron');
+	// Mobile nav accordions
+	document.querySelectorAll<HTMLElement>('[data-accordion-btn]').forEach((accordionBtn) => {
+		const id = accordionBtn.getAttribute('data-accordion-btn');
+		if (!id) return;
+		const accordionPanel = document.querySelector<HTMLElement>(`[data-accordion-panel="${id}"]`);
+		const accordionChevron = document.querySelector<HTMLElement>(`[data-accordion-chevron="${id}"]`);
 
-	accordionBtn?.addEventListener('click', () => {
-		const expanded = accordionBtn.getAttribute('aria-expanded') === 'true';
-		const nextExpanded = !expanded;
-		accordionBtn.setAttribute('aria-expanded', String(nextExpanded));
-		accordionPanel?.classList.toggle('hidden', !nextExpanded);
-		accordionChevron?.classList.toggle('rotate-180', nextExpanded);
+		accordionBtn.addEventListener('click', () => {
+			const expanded = accordionBtn.getAttribute('aria-expanded') === 'true';
+			const nextExpanded = !expanded;
+			accordionBtn.setAttribute('aria-expanded', String(nextExpanded));
+			accordionPanel?.classList.toggle('hidden', !nextExpanded);
+			accordionChevron?.classList.toggle('rotate-180', nextExpanded);
+		});
 	});
 
-	// Desktop catalogs flyout
-	const flyoutTrigger = document.getElementById('catalogs-flyout-trigger');
-	const flyout = document.getElementById('catalogs-flyout');
+	// Desktop nav flyouts
+	type FlyoutGroup = {
+		trigger: HTMLElement;
+		flyout: HTMLElement;
+		openTimer: ReturnType<typeof setTimeout> | null;
+		closeTimer: ReturnType<typeof setTimeout> | null;
+		open: boolean;
+	};
 
-	let openTimer: ReturnType<typeof setTimeout> | null = null;
-	let closeTimer: ReturnType<typeof setTimeout> | null = null;
-	let flyoutOpen = false;
+	const flyoutGroups: FlyoutGroup[] = [];
+
 	function isLargeScreen(): boolean {
 		return window.matchMedia(LG_QUERY).matches;
 	}
 
-	function positionFlyout(): void {
-		if (!flyoutTrigger || !flyout) return;
-		const rect = flyoutTrigger.getBoundingClientRect();
-		flyout.style.top = `${rect.top}px`;
-		flyout.style.left = '14rem';
+	function clearFlyoutTimers(group: FlyoutGroup): void {
+		if (group.openTimer) {
+			clearTimeout(group.openTimer);
+			group.openTimer = null;
+		}
+		if (group.closeTimer) {
+			clearTimeout(group.closeTimer);
+			group.closeTimer = null;
+		}
 	}
 
-	function setFlyoutOpen(open: boolean, focusFirstLink = false): void {
-		if (!flyoutTrigger || !flyout) return;
-		flyoutOpen = open;
-		flyout.classList.toggle('hidden', !open);
-		flyoutTrigger.setAttribute('aria-expanded', String(open));
+	function positionFlyout(group: FlyoutGroup): void {
+		const rect = group.trigger.getBoundingClientRect();
+		group.flyout.style.top = `${rect.top}px`;
+		group.flyout.style.left = '14rem';
+	}
+
+	function setFlyoutOpen(group: FlyoutGroup, open: boolean, focusFirstLink = false): void {
+		group.open = open;
+		group.flyout.classList.toggle('hidden', !open);
+		group.trigger.setAttribute('aria-expanded', String(open));
 		if (open) {
-			positionFlyout();
+			positionFlyout(group);
 			if (focusFirstLink) {
-				const firstLink = flyout.querySelector<HTMLAnchorElement>('a[role="menuitem"]');
+				const firstLink = group.flyout.querySelector<HTMLAnchorElement>('a[role="menuitem"]');
 				firstLink?.focus();
 			}
 		}
 	}
 
-	function clearTimers(): void {
-		if (openTimer) {
-			clearTimeout(openTimer);
-			openTimer = null;
-		}
-		if (closeTimer) {
-			clearTimeout(closeTimer);
-			closeTimer = null;
-		}
+	function scheduleFlyoutOpen(group: FlyoutGroup): void {
+		if (!isLargeScreen()) return;
+		clearFlyoutTimers(group);
+		group.closeTimer = null;
+		group.openTimer = setTimeout(() => setFlyoutOpen(group, true), OPEN_DELAY);
 	}
 
-	function scheduleFlyoutOpen(): void {
+	function scheduleFlyoutClose(group: FlyoutGroup): void {
 		if (!isLargeScreen()) return;
-		clearTimers();
-		closeTimer = null;
-		openTimer = setTimeout(() => setFlyoutOpen(true), OPEN_DELAY);
+		clearFlyoutTimers(group);
+		group.openTimer = null;
+		group.closeTimer = setTimeout(() => setFlyoutOpen(group, false), CLOSE_DELAY);
 	}
 
-	function scheduleFlyoutClose(): void {
-		if (!isLargeScreen()) return;
-		clearTimers();
-		openTimer = null;
-		closeTimer = setTimeout(() => setFlyoutOpen(false), CLOSE_DELAY);
+	function bindHoverZone(group: FlyoutGroup, element: HTMLElement | null): void {
+		element?.addEventListener('mouseenter', () => scheduleFlyoutOpen(group));
+		element?.addEventListener('mouseleave', () => scheduleFlyoutClose(group));
 	}
 
-	function bindHoverZone(element: HTMLElement | null): void {
-		element?.addEventListener('mouseenter', scheduleFlyoutOpen);
-		element?.addEventListener('mouseleave', scheduleFlyoutClose);
-	}
+	document.querySelectorAll<HTMLElement>('[data-flyout-trigger]').forEach((trigger) => {
+		const id = trigger.getAttribute('data-flyout-trigger');
+		if (!id) return;
+		const flyout = document.querySelector<HTMLElement>(`[data-flyout="${id}"]`);
+		if (!flyout) return;
 
-	bindHoverZone(flyoutTrigger);
-	bindHoverZone(flyout);
+		const group: FlyoutGroup = {
+			trigger,
+			flyout,
+			openTimer: null,
+			closeTimer: null,
+			open: false,
+		};
+		flyoutGroups.push(group);
 
-	flyoutTrigger?.addEventListener('focus', () => {
-		if (isLargeScreen()) scheduleFlyoutOpen();
-	});
+		bindHoverZone(group, trigger);
+		bindHoverZone(group, flyout);
 
-	flyoutTrigger?.addEventListener('blur', (event) => {
-		if (!isLargeScreen()) return;
-		const related = event.relatedTarget as Node | null;
-		if (related && flyout?.contains(related)) return;
-		scheduleFlyoutClose();
-	});
+		trigger.addEventListener('focus', () => {
+			if (isLargeScreen()) scheduleFlyoutOpen(group);
+		});
 
-	flyout?.addEventListener('focusout', (event) => {
-		if (!isLargeScreen() || !flyoutOpen) return;
-		const related = event.relatedTarget as Node | null;
-		if (related && (flyout.contains(related) || flyoutTrigger?.contains(related))) return;
-		scheduleFlyoutClose();
-	});
+		trigger.addEventListener('blur', (event) => {
+			if (!isLargeScreen()) return;
+			const related = event.relatedTarget as Node | null;
+			if (related && flyout.contains(related)) return;
+			scheduleFlyoutClose(group);
+		});
 
-	flyoutTrigger?.addEventListener('click', (event) => {
-		if (!isLargeScreen()) return;
-		event.preventDefault();
-		clearTimers();
-		if (flyoutOpen) {
-			setFlyoutOpen(false);
-		} else {
-			const fromKeyboard = event.detail === 0;
-			setFlyoutOpen(true, fromKeyboard);
-		}
+		flyout.addEventListener('focusout', (event) => {
+			if (!isLargeScreen() || !group.open) return;
+			const related = event.relatedTarget as Node | null;
+			if (related && (flyout.contains(related) || trigger.contains(related))) return;
+			scheduleFlyoutClose(group);
+		});
+
+		trigger.addEventListener('click', (event) => {
+			if (!isLargeScreen()) return;
+			event.preventDefault();
+			clearFlyoutTimers(group);
+			if (group.open) {
+				setFlyoutOpen(group, false);
+			} else {
+				const fromKeyboard = event.detail === 0;
+				setFlyoutOpen(group, true, fromKeyboard);
+			}
+		});
 	});
 
 	document.addEventListener('keydown', (event) => {
-		if (event.key === 'Escape' && flyoutOpen && isLargeScreen()) {
-			event.preventDefault();
-			clearTimers();
-			setFlyoutOpen(false);
-			flyoutTrigger?.focus();
+		if (event.key === 'Escape' && isLargeScreen()) {
+			const openGroup = flyoutGroups.find((group) => group.open);
+			if (openGroup) {
+				event.preventDefault();
+				clearFlyoutTimers(openGroup);
+				setFlyoutOpen(openGroup, false);
+				openGroup.trigger.focus();
+			}
 		}
 		if (event.key === 'Escape' && mobileSidebar?.getAttribute('aria-hidden') === 'false') {
 			closeMobileDrawer();
@@ -702,14 +884,18 @@ const sectionLabelClasses =
 	});
 
 	window.addEventListener('resize', () => {
-		if (flyoutOpen) positionFlyout();
-		if (!isLargeScreen()) {
-			clearTimers();
-			setFlyoutOpen(false);
+		for (const group of flyoutGroups) {
+			if (group.open) positionFlyout(group);
+			if (!isLargeScreen()) {
+				clearFlyoutTimers(group);
+				setFlyoutOpen(group, false);
+			}
 		}
 	});
 
 	window.addEventListener('scroll', () => {
-		if (flyoutOpen) positionFlyout();
+		for (const group of flyoutGroups) {
+			if (group.open) positionFlyout(group);
+		}
 	}, true);
 </script>

--- a/src/layouts/Sidebar.astro
+++ b/src/layouts/Sidebar.astro
@@ -17,13 +17,28 @@ interface NavItem {
 	icon: string;
 }
 
-const { slug } = Astro.props;
+const pathname = Astro.url.pathname;
 
-const isNavItemActive = (href: string): boolean => {
-	if (!slug) return false;
-	const hrefSegment = href.replace(/^\/+|\/+$/g, '').split('/')[0] ?? '';
-	const slugSegment = slug.replace(/^\/+|\/+$/g, '').split('/')[0] ?? '';
-	return hrefSegment !== '' && hrefSegment === slugSegment;
+const normalizePath = (path: string): string => path.replace(/\/+$/, '') || '/';
+
+const isPathMatch = (normalizedPathname: string, normalizedHref: string): boolean =>
+	normalizedPathname === normalizedHref || normalizedPathname.startsWith(`${normalizedHref}/`);
+
+const getBestMatchHref = (currentPathname: string, navHrefs: string[]): string | null => {
+	const normalizedPathname = normalizePath(currentPathname);
+	let bestMatch: string | null = null;
+	let bestLength = -1;
+
+	for (const href of navHrefs) {
+		const normalizedHref = normalizePath(href);
+		if (!isPathMatch(normalizedPathname, normalizedHref)) continue;
+		if (normalizedHref.length > bestLength) {
+			bestMatch = href;
+			bestLength = normalizedHref.length;
+		}
+	}
+
+	return bestMatch;
 };
 
 const toolsNav: NavItem[] = [
@@ -36,7 +51,7 @@ const calculatorsNav: NavItem[] = [
 	{ name: 'Calculator', href: '/calculator', icon: 'calculator' },
 	{ name: 'Crafting Planner', href: '/calculator/planner', icon: 'archive-box' },
 	{ name: 'Reverse Calculator', href: '/calculator/reverse', icon: 'scale' },
-	{ name: 'Farm Calculator', href: '/farm', icon: 'sun' },
+	{ name: 'Farm Calculator', href: '/calculator/farm', icon: 'sun' },
 ];
 
 const catalogsNav: NavItem[] = [
@@ -62,8 +77,13 @@ const moreNav: NavItem[] = [
 	{ name: 'Feedback', href: '/feedback', icon: 'envelope' },
 ];
 
-const isCalculatorsActive = calculatorsNav.some((item) => isNavItemActive(item.href));
-const isCatalogActive = catalogsNav.some((item) => isNavItemActive(item.href));
+const allNavHrefs = [...toolsNav, ...calculatorsNav, ...catalogsNav, ...moreNav].map((item) => item.href);
+const activeHref = getBestMatchHref(pathname, allNavHrefs);
+const isNavItemActive = (href: string): boolean => activeHref !== null && href === activeHref;
+const calculatorsHrefs = new Set(calculatorsNav.map((item) => item.href));
+const catalogsHrefs = new Set(catalogsNav.map((item) => item.href));
+const isCalculatorsActive = activeHref !== null && calculatorsHrefs.has(activeHref);
+const isCatalogActive = activeHref !== null && catalogsHrefs.has(activeHref);
 
 const icons: Record<string, IconPath[]> = {
 	funnel: [

--- a/src/pages/calculator/farm/index.astro
+++ b/src/pages/calculator/farm/index.astro
@@ -8,9 +8,10 @@ import { SITE } from '@config';
 const IMAGE_BASE = SITE.imageBaseUrl;
 const plants = getAllGrowablePlants();
 const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
-const canonicalUrl = new URL('/farm', siteOrigin).toString();
+const canonicalUrl = new URL('/calculator/farm', siteOrigin).toString();
 const breadcrumbs = [
 	{ name: 'Home', href: '/' },
+	{ name: 'Crafting Calculator', href: '/calculator' },
 	{ name: 'Farm Calculator' },
 ];
 const title = "Farm Calculator | No Man's Sky Recipes";
@@ -22,13 +23,14 @@ const breadcrumbSchema = {
 	'@id': `${canonicalUrl}#breadcrumb`,
 	itemListElement: [
 		{ '@type': 'ListItem', position: 1, name: 'Home', item: `${siteOrigin}/` },
-		{ '@type': 'ListItem', position: 2, name: 'Farm Calculator', item: canonicalUrl },
+		{ '@type': 'ListItem', position: 2, name: 'Crafting Calculator', item: `${siteOrigin}/calculator` },
+		{ '@type': 'ListItem', position: 3, name: 'Farm Calculator', item: canonicalUrl },
 	],
 };
 const structuredData = [breadcrumbSchema];
 ---
 
-<Layout {title} {description} slug="farm" structuredData={structuredData}>
+<Layout {title} {description} slug="calculator" structuredData={structuredData}>
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">Farm Calculator</h1>
 	<p class="mx-auto mb-8 max-w-3xl text-center text-sky-200/90">

--- a/src/pages/calculator/index.astro
+++ b/src/pages/calculator/index.astro
@@ -62,6 +62,21 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Calculator</h1>
 	<p class="mx-auto mb-4 mt-3 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="text-center mb-6 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
+		<a
+			href="/calculator/planner"
+			class="text-lg font-medium text-cyan-300 underline-offset-2 hover:text-cyan-200 hover:underline"
+		>
+			Try the multi-item Crafting Planner →
+		</a>
+		<span class="hidden text-sky-600 sm:inline" aria-hidden="true">·</span>
+		<a
+			href="/calculator/reverse"
+			class="text-lg font-medium text-cyan-300 underline-offset-2 hover:text-cyan-200 hover:underline"
+		>
+			What can I make with an item? Reverse Calculator →
+		</a>
+	</p>
 	<p class="text-xl text-center mt-3 mb-8">Choose an item below to start</p>
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
 		{

--- a/src/pages/calculator/planner-data.json.ts
+++ b/src/pages/calculator/planner-data.json.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { Products } from '@datav2/index.js';
+import * as dataSources from '@datav2/index.js';
 import { createArray } from '@utils/recipeTree.js';
 import { getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
@@ -19,8 +19,19 @@ type PlannerProduct = {
 	rawItems: PlannerRawItem[];
 };
 
-const body: PlannerProduct[] = (Products as Item[])
-	.filter((item) => item.RequiredItems && item.RequiredItems.length > 0)
+const allData = Object.values(dataSources).flatMap((source) =>
+	Array.isArray(source) ? (source as Item[]) : [],
+);
+
+const seenIds = new Set<string>();
+const craftableItems = allData.filter((item) => {
+	if (!item.RequiredItems || item.RequiredItems.length === 0) return false;
+	if (seenIds.has(item.Id)) return false;
+	seenIds.add(item.Id);
+	return true;
+});
+
+const body: PlannerProduct[] = craftableItems
 	.map((item) => {
 		const { rawItems } = createArray(item, 1);
 		return {

--- a/src/pages/calculator/planner-data.json.ts
+++ b/src/pages/calculator/planner-data.json.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from 'astro';
+import { Products } from '@datav2/index.js';
+import { createArray } from '@utils/recipeTree.js';
+import { getSlug } from '@utils/lookup.js';
+import type { Item } from '@utils/lookup.js';
+
+type PlannerRawItem = {
+	id: string;
+	name: string;
+	icon: string;
+	quantity: number;
+};
+
+type PlannerProduct = {
+	id: string;
+	name: string;
+	icon: string;
+	url: string;
+	rawItems: PlannerRawItem[];
+};
+
+const body: PlannerProduct[] = (Products as Item[])
+	.filter((item) => item.RequiredItems && item.RequiredItems.length > 0)
+	.map((item) => {
+		const { rawItems } = createArray(item, 1);
+		return {
+			item,
+			rawItems,
+		};
+	})
+	.filter(({ rawItems }) => rawItems.length > 0)
+	.map(({ item, rawItems }) => ({
+		id: item.Id,
+		name: item.Name,
+		icon: item.Icon,
+		url: getSlug(item),
+		rawItems: rawItems.map((rawItem) => ({
+			id: rawItem.Id,
+			name: rawItem.Name,
+			icon: rawItem.Icon,
+			quantity: rawItem.Quantity,
+		})),
+	}))
+	.sort((a, b) => a.name.localeCompare(b.name));
+
+export const GET: APIRoute = () => {
+	return new Response(JSON.stringify({ body }), {
+		headers: {
+			'Content-Type': 'application/json',
+			'Cache-Control': 'public, max-age=300',
+		},
+	});
+};

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -1,0 +1,563 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Breadcrumbs from '@components/Breadcrumbs.astro';
+import { getSiteOrigin } from '@utils/structuredData.js';
+import { SITE } from '@config';
+
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/calculator/planner', siteOrigin).toString();
+const title = 'Crafting Planner | No Man\'s Sky Recipes';
+const description =
+	'Plan multiple crafted products at once. Add items and quantities to see total raw materials needed across your entire build list.';
+const breadcrumbs = [
+	{ name: 'Home', href: '/' },
+	{ name: 'Crafting Calculator', href: '/calculator' },
+	{ name: 'Crafting Planner' },
+];
+const breadcrumbSchema = {
+	'@context': 'https://schema.org',
+	'@type': 'BreadcrumbList',
+	'@id': `${canonicalUrl}#breadcrumb`,
+	itemListElement: [
+		{ '@type': 'ListItem', position: 1, name: 'Home', item: `${siteOrigin}/` },
+		{ '@type': 'ListItem', position: 2, name: 'Crafting Calculator', item: `${siteOrigin}/calculator` },
+		{ '@type': 'ListItem', position: 3, name: 'Crafting Planner', item: canonicalUrl },
+	],
+};
+const imageBaseUrl = SITE.imageBaseUrl;
+---
+
+<Layout
+	{title}
+	{description}
+	slug="calculator"
+	structuredData={breadcrumbSchema}
+	ogImage={`${SITE.website}/images/calculator.webp`}
+>
+	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
+	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Planner</h1>
+	<p class="mx-auto mb-8 mt-3 max-w-3xl text-center text-sky-200/90">
+		Add multiple products with quantities to see the combined raw materials you need. Share your plan via URL.
+	</p>
+
+	<div
+		id="planner-app"
+		class="mx-auto max-w-4xl px-4 pb-12"
+		data-image-base={imageBaseUrl}
+	>
+		<div class="mb-6">
+			<label for="product-search" class="sr-only">Search products</label>
+			<input
+				id="product-search"
+				type="text"
+				autocomplete="off"
+				placeholder="Search products to add…"
+				class="h-12 w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+			/>
+			<div
+				id="product-results"
+				class="mt-2 max-h-64 overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
+				role="listbox"
+				aria-label="Matching products"
+			></div>
+		</div>
+
+		<section aria-labelledby="plan-heading" class="mb-8">
+			<h2 id="plan-heading" class="text-2xl mb-4">Your plan</h2>
+			<div id="plan-rows" class="flex flex-col gap-2"></div>
+			<p id="plan-empty" class="text-sky-200/70 text-sm">
+				No items added yet. Search above to add products (e.g. Stasis Device, Living Glass).
+			</p>
+		</section>
+
+		<section aria-labelledby="totals-heading" class="mb-6">
+			<div class="flex flex-wrap items-center justify-between gap-4 mb-4">
+				<h2 id="totals-heading" class="text-2xl mb-0">Total raw materials</h2>
+				<div class="flex flex-wrap items-center gap-3">
+					<label class="inline-flex cursor-pointer items-center gap-2 text-sm text-sky-200">
+						<input
+							id="breakdown-toggle"
+							type="checkbox"
+							class="peer hidden"
+						/>
+						<span class="select-none rounded-lg border-2 border-sky-600 px-2 py-0.5 transition-colors duration-200 peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
+							Show per-item breakdown
+						</span>
+					</label>
+					<button
+						id="copy-link-btn"
+						type="button"
+						class="rounded-sm border border-sky-600 bg-sky-900/50 px-3 py-1.5 text-sm text-cyan-300 hover:border-cyan-400 hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
+						disabled
+					>
+						Copy link
+					</button>
+				</div>
+			</div>
+			<div id="totals-list"></div>
+			<p id="totals-empty" class="text-sky-200/70 text-sm hidden">
+				Add products to your plan to see total raw materials.
+			</p>
+			<div id="breakdown-section" class="mt-6 hidden"></div>
+		</section>
+	</div>
+</Layout>
+
+<script>
+	type PlannerRawItem = {
+		id: string;
+		name: string;
+		icon: string;
+		quantity: number;
+	};
+
+	type PlannerProduct = {
+		id: string;
+		name: string;
+		icon: string;
+		url: string;
+		rawItems: PlannerRawItem[];
+	};
+
+	type PlanEntry = {
+		id: string;
+		qty: number;
+	};
+
+	type MergedRawItem = PlannerRawItem;
+
+	const plannerApp = document.getElementById('planner-app');
+	const productSearch = document.getElementById('product-search') as HTMLInputElement | null;
+	const productResults = document.getElementById('product-results');
+	const planRows = document.getElementById('plan-rows');
+	const planEmpty = document.getElementById('plan-empty');
+	const totalsList = document.getElementById('totals-list');
+	const totalsEmpty = document.getElementById('totals-empty');
+	const breakdownToggle = document.getElementById('breakdown-toggle') as HTMLInputElement | null;
+	const breakdownSection = document.getElementById('breakdown-section');
+	const copyLinkBtn = document.getElementById('copy-link-btn') as HTMLButtonElement | null;
+
+	const imageBaseUrl = plannerApp?.dataset.imageBase ?? '/images/items/';
+
+	let products: PlannerProduct[] = [];
+	const productsById = new Map<string, PlannerProduct>();
+	let plan: PlanEntry[] = [];
+	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let urlDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let datasetPromise: Promise<PlannerProduct[]> | null = null;
+
+	function loadPlannerDataset(): Promise<PlannerProduct[]> {
+		if (!datasetPromise) {
+			datasetPromise = fetch('/calculator/planner-data.json', { cache: 'force-cache' })
+				.then((response) => response.json())
+				.then((results) => {
+					if (!results || !Array.isArray(results.body)) {
+						return [];
+					}
+					return results.body.filter(
+						(entry: PlannerProduct) =>
+							entry &&
+							typeof entry.id === 'string' &&
+							typeof entry.name === 'string' &&
+							Array.isArray(entry.rawItems)
+					);
+				})
+				.catch((error) => {
+					datasetPromise = null;
+					throw error;
+				});
+		}
+		return datasetPromise;
+	}
+
+	function parsePlanFromUrl(): PlanEntry[] {
+		const itemsParam = new URLSearchParams(window.location.search).get('items');
+		if (!itemsParam) return [];
+
+		return itemsParam
+			.split(',')
+			.map((segment) => {
+				const [id, qtyStr] = segment.split(':');
+				if (!id) return null;
+				const qty = Number.parseInt(qtyStr ?? '1', 10);
+				if (!Number.isFinite(qty) || qty < 1) return null;
+				return { id, qty };
+			})
+			.filter((entry): entry is PlanEntry => entry !== null && productsById.has(entry.id));
+	}
+
+	function updateUrl() {
+		if (urlDebounceTimer) {
+			clearTimeout(urlDebounceTimer);
+		}
+		urlDebounceTimer = setTimeout(() => {
+			const params = new URLSearchParams();
+			if (plan.length > 0) {
+				params.set('items', plan.map((entry) => `${entry.id}:${entry.qty}`).join(','));
+			}
+			const query = params.toString();
+			const newUrl = `/calculator/planner${query ? `?${query}` : ''}`;
+			window.history.replaceState({}, '', newUrl);
+			if (copyLinkBtn) {
+				copyLinkBtn.disabled = plan.length === 0;
+			}
+		}, 200);
+	}
+
+	function mergeRawItems(entries: PlanEntry[]): MergedRawItem[] {
+		const merged = new Map<string, MergedRawItem>();
+
+		for (const entry of entries) {
+			const product = productsById.get(entry.id);
+			if (!product) continue;
+
+			for (const rawItem of product.rawItems) {
+				const totalQty = rawItem.quantity * entry.qty;
+				const existing = merged.get(rawItem.id);
+				if (existing) {
+					existing.quantity += totalQty;
+				} else {
+					merged.set(rawItem.id, {
+						id: rawItem.id,
+						name: rawItem.name,
+						icon: rawItem.icon,
+						quantity: totalQty,
+					});
+				}
+			}
+		}
+
+		return Array.from(merged.values()).sort((a, b) => b.quantity - a.quantity);
+	}
+
+	function createRawItemRow(rawItem: MergedRawItem): HTMLLIElement {
+		const li = document.createElement('li');
+		li.className = 'flex items-center gap-3 py-1.5';
+
+		if (rawItem.icon) {
+			const img = document.createElement('img');
+			img.src = `${imageBaseUrl}${rawItem.icon}`;
+			img.alt = '';
+			img.className = 'h-6 w-6 shrink-0 object-contain';
+			img.loading = 'lazy';
+			li.appendChild(img);
+		}
+
+		const nameSpan = document.createElement('span');
+		nameSpan.className = 'flex-1';
+		nameSpan.textContent = rawItem.name;
+		li.appendChild(nameSpan);
+
+		const qtySpan = document.createElement('span');
+		qtySpan.className =
+			'inline-flex min-w-[1.75rem] items-center justify-center rounded-sm bg-gray-700/80 px-1.5 py-0.5 text-xs font-medium tabular-nums text-gray-300';
+		qtySpan.textContent = rawItem.quantity.toLocaleString();
+		li.appendChild(qtySpan);
+
+		return li;
+	}
+
+	function renderTotals() {
+		if (!totalsList || !totalsEmpty || !breakdownSection) return;
+
+		totalsList.textContent = '';
+		breakdownSection.textContent = '';
+
+		if (plan.length === 0) {
+			totalsEmpty.classList.remove('hidden');
+			breakdownSection.classList.add('hidden');
+			return;
+		}
+
+		totalsEmpty.classList.add('hidden');
+		const merged = mergeRawItems(plan);
+
+		const ul = document.createElement('ul');
+		ul.className = 'm-0 flex list-none flex-col gap-1 p-0';
+		for (const rawItem of merged) {
+			ul.appendChild(createRawItemRow(rawItem));
+		}
+		totalsList.appendChild(ul);
+
+		if (breakdownToggle?.checked) {
+			breakdownSection.classList.remove('hidden');
+			for (const entry of plan) {
+				const product = productsById.get(entry.id);
+				if (!product) continue;
+
+				const heading = document.createElement('h3');
+				heading.className = 'text-lg mt-4 mb-2 text-cyan-200';
+				heading.textContent = `${product.name} × ${entry.qty.toLocaleString()}`;
+				breakdownSection.appendChild(heading);
+
+				const itemUl = document.createElement('ul');
+				itemUl.className = 'm-0 flex list-none flex-col gap-1 p-0 pl-2 border-l border-sky-800';
+				const scaled = product.rawItems
+					.map((rawItem) => ({
+						...rawItem,
+						quantity: rawItem.quantity * entry.qty,
+					}))
+					.sort((a, b) => b.quantity - a.quantity);
+
+				for (const rawItem of scaled) {
+					itemUl.appendChild(createRawItemRow(rawItem));
+				}
+				breakdownSection.appendChild(itemUl);
+			}
+		} else {
+			breakdownSection.classList.add('hidden');
+		}
+	}
+
+	function focusPlanQty(productId: string) {
+		const qtyInput = planRows?.querySelector(
+			`input[data-product-id="${productId}"]`
+		) as HTMLInputElement | null;
+		if (qtyInput) {
+			qtyInput.focus();
+			qtyInput.select();
+		}
+	}
+
+	function addToPlan(productId: string) {
+		const existing = plan.find((entry) => entry.id === productId);
+		if (existing) {
+			focusPlanQty(productId);
+			return;
+		}
+
+		plan.push({ id: productId, qty: 1 });
+		renderPlan();
+		updateUrl();
+	}
+
+	function removeFromPlan(productId: string) {
+		plan = plan.filter((entry) => entry.id !== productId);
+		renderPlan();
+		updateUrl();
+	}
+
+	function setPlanQty(productId: string, qty: number) {
+		const entry = plan.find((item) => item.id === productId);
+		if (!entry) return;
+		entry.qty = Math.max(1, qty);
+		renderTotals();
+		updateUrl();
+	}
+
+	function renderPlan() {
+		if (!planRows || !planEmpty) return;
+
+		planRows.textContent = '';
+
+		if (plan.length === 0) {
+			planEmpty.classList.remove('hidden');
+			renderTotals();
+			return;
+		}
+
+		planEmpty.classList.add('hidden');
+
+		for (const entry of plan) {
+			const product = productsById.get(entry.id);
+			if (!product) continue;
+
+			const row = document.createElement('div');
+			row.className =
+				'flex flex-wrap items-center gap-3 rounded-sm border border-sky-800 bg-sky-900/30 px-3 py-2';
+			row.dataset.productId = product.id;
+
+			if (product.icon) {
+				const img = document.createElement('img');
+				img.src = `${imageBaseUrl}${product.icon}`;
+				img.alt = '';
+				img.className = 'h-8 w-8 shrink-0 object-contain';
+				img.loading = 'lazy';
+				row.appendChild(img);
+			}
+
+			const nameLink = document.createElement('a');
+			nameLink.href = product.url;
+			nameLink.className = 'flex-1 min-w-0 truncate text-cyan-300 hover:text-cyan-200 hover:underline';
+			nameLink.textContent = product.name;
+			row.appendChild(nameLink);
+
+			const qtyInput = document.createElement('input');
+			qtyInput.type = 'number';
+			qtyInput.min = '1';
+			qtyInput.step = '1';
+			qtyInput.value = String(entry.qty);
+			qtyInput.id = `qty-${product.id}`;
+			qtyInput.dataset.productId = product.id;
+			qtyInput.className =
+				'h-9 w-20 rounded-sm border border-sky-700 bg-black/40 px-2 text-center text-white focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400';
+			qtyInput.addEventListener('change', () => {
+				const parsed = Number.parseInt(qtyInput.value, 10);
+				setPlanQty(product.id, Number.isFinite(parsed) ? parsed : 1);
+			});
+			qtyInput.addEventListener('input', () => {
+				const parsed = Number.parseInt(qtyInput.value, 10);
+				if (Number.isFinite(parsed) && parsed >= 1) {
+					entry.qty = parsed;
+					renderTotals();
+				}
+			});
+
+			const qtyLabel = document.createElement('label');
+			qtyLabel.className = 'sr-only';
+			qtyLabel.textContent = `Quantity for ${product.name}`;
+			qtyLabel.htmlFor = qtyInput.id;
+
+			row.appendChild(qtyLabel);
+			row.appendChild(qtyInput);
+
+			const removeBtn = document.createElement('button');
+			removeBtn.type = 'button';
+			removeBtn.className =
+				'flex h-9 w-9 shrink-0 items-center justify-center rounded-sm text-xl text-sky-300 hover:bg-sky-800/60 hover:text-white';
+			removeBtn.setAttribute('aria-label', `Remove ${product.name}`);
+			removeBtn.textContent = '×';
+			removeBtn.addEventListener('click', () => removeFromPlan(product.id));
+			row.appendChild(removeBtn);
+
+			planRows.appendChild(row);
+		}
+
+		renderTotals();
+	}
+
+	function renderProductSearch() {
+		if (!productSearch || !productResults) return;
+
+		const term = productSearch.value.trim().toLowerCase();
+		productResults.textContent = '';
+
+		if (!term) {
+			productResults.classList.add('hidden');
+			return;
+		}
+
+		const matches = products
+			.filter((product) => product.name.toLowerCase().includes(term))
+			.sort((a, b) => {
+				const aName = a.name.toLowerCase();
+				const bName = b.name.toLowerCase();
+				if (aName === term) return -1;
+				if (bName === term) return 1;
+				if (aName.startsWith(term) && !bName.startsWith(term)) return -1;
+				if (bName.startsWith(term) && !aName.startsWith(term)) return 1;
+				return a.name.localeCompare(b.name);
+			})
+			.slice(0, 50);
+
+		if (matches.length === 0) {
+			productResults.classList.remove('hidden');
+			const empty = document.createElement('p');
+			empty.className = 'p-3 text-sm text-sky-200/70';
+			empty.textContent = 'No matching products found.';
+			productResults.appendChild(empty);
+			return;
+		}
+
+		productResults.classList.remove('hidden');
+		const ul = document.createElement('ul');
+		ul.className = 'm-0 list-none p-0';
+
+		for (const product of matches) {
+			const li = document.createElement('li');
+			li.setAttribute('role', 'option');
+
+			const btn = document.createElement('button');
+			btn.type = 'button';
+			btn.className =
+				'flex w-full items-center gap-2 px-3 py-2 text-left text-white hover:bg-sky-800/60';
+
+			if (product.icon) {
+				const img = document.createElement('img');
+				img.src = `${imageBaseUrl}${product.icon}`;
+				img.alt = '';
+				img.className = 'h-6 w-6 shrink-0 object-contain';
+				img.loading = 'lazy';
+				btn.appendChild(img);
+			}
+
+			const nameSpan = document.createElement('span');
+			nameSpan.textContent = product.name;
+			btn.appendChild(nameSpan);
+
+			const inPlan = plan.some((entry) => entry.id === product.id);
+			if (inPlan) {
+				const badge = document.createElement('span');
+				badge.className = 'ml-auto text-xs text-sky-400';
+				badge.textContent = 'In plan';
+				btn.appendChild(badge);
+			}
+
+			btn.addEventListener('click', () => {
+				addToPlan(product.id);
+				productSearch.value = '';
+				productResults.classList.add('hidden');
+				productResults.textContent = '';
+			});
+
+			li.appendChild(btn);
+			ul.appendChild(li);
+		}
+
+		productResults.appendChild(ul);
+	}
+
+	async function init() {
+		try {
+			products = await loadPlannerDataset();
+			productsById.clear();
+			for (const product of products) {
+				productsById.set(product.id, product);
+			}
+
+			plan = parsePlanFromUrl();
+			renderPlan();
+			updateUrl();
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error('Failed to load planner data:', error);
+			}
+			if (planEmpty) {
+				planEmpty.textContent = 'Unable to load product data. Please refresh the page.';
+			}
+		}
+	}
+
+	if (productSearch) {
+		productSearch.addEventListener('input', () => {
+			if (searchDebounceTimer) {
+				clearTimeout(searchDebounceTimer);
+			}
+			searchDebounceTimer = setTimeout(renderProductSearch, 200);
+		});
+	}
+
+	if (breakdownToggle) {
+		breakdownToggle.addEventListener('change', renderTotals);
+	}
+
+	if (copyLinkBtn) {
+		copyLinkBtn.addEventListener('click', async () => {
+			try {
+				await navigator.clipboard.writeText(window.location.href);
+				const originalText = copyLinkBtn.textContent;
+				copyLinkBtn.textContent = 'Copied!';
+				setTimeout(() => {
+					copyLinkBtn.textContent = originalText;
+				}, 2000);
+			} catch {
+				copyLinkBtn.textContent = 'Copy failed';
+				setTimeout(() => {
+					copyLinkBtn.textContent = 'Copy link';
+				}, 2000);
+			}
+		});
+	}
+
+	init();
+</script>

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -52,11 +52,11 @@ const imageBaseUrl = SITE.imageBaseUrl;
 				type="text"
 				autocomplete="off"
 				placeholder="Search products to add…"
-				class="h-12 w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+				class="box-border h-12 w-full max-w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
 			/>
 			<div
 				id="product-results"
-				class="mt-2 max-h-64 overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
+				class="box-border mt-2 max-h-64 max-w-full overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
 				role="listbox"
 				aria-label="Matching products"
 			></div>

--- a/src/pages/calculator/reverse-data.json.ts
+++ b/src/pages/calculator/reverse-data.json.ts
@@ -1,0 +1,170 @@
+import type { APIRoute } from 'astro';
+import {
+	findInputFromRefiner,
+	findInputFromCooking,
+	findInputFromCrafting,
+	getById,
+	getSlug,
+} from '@utils/lookup.js';
+import {
+	Refinery,
+	NutrientProcessor,
+	Products,
+	Food,
+	Curiosities,
+	Fish,
+	ConstructedTechnology,
+	Technology,
+	TechnologyModule,
+	Others,
+	Buildings,
+	Trade,
+	Upgrades,
+	Exocraft,
+	Starships,
+	Corvette,
+} from '@datav2/index.js';
+
+type RecipeWithInputs = {
+	Id: string;
+	Inputs: Array<{ Id: string; Quantity: number }>;
+	Output?: { Id: string; Quantity: number };
+};
+
+type ReverseRecipeInput = {
+	id: string;
+	name: string;
+	icon: string;
+	quantity: number;
+};
+
+type ReverseRecipe = {
+	method: 'refine' | 'cook' | 'craft';
+	outputId: string;
+	outputName: string;
+	outputIcon: string;
+	outputUrl: string;
+	outputQuantity: number;
+	inputs: ReverseRecipeInput[];
+};
+
+type ReverseEntry = {
+	id: string;
+	name: string;
+	icon: string;
+	recipes: ReverseRecipe[];
+};
+
+function collectInputIds(): Set<string> {
+	const ids = new Set<string>();
+
+	for (const recipe of Refinery as Array<{ Inputs?: Array<{ Id: string }> }>) {
+		for (const input of recipe.Inputs ?? []) {
+			ids.add(input.Id);
+		}
+	}
+
+	for (const recipe of NutrientProcessor as Array<{ Inputs?: Array<{ Id: string }> }>) {
+		for (const input of recipe.Inputs ?? []) {
+			ids.add(input.Id);
+		}
+	}
+
+	const craftingSources = [
+		Products,
+		Food,
+		Curiosities,
+		Fish,
+		ConstructedTechnology,
+		Technology,
+		TechnologyModule,
+		Others,
+		Buildings,
+		Trade,
+		Upgrades,
+		Exocraft,
+		Starships,
+		Corvette,
+	] as Array<Array<{ RequiredItems?: Array<{ Id: string }> }>>;
+
+	for (const source of craftingSources) {
+		for (const item of source) {
+			for (const required of item.RequiredItems ?? []) {
+				ids.add(required.Id);
+			}
+		}
+	}
+
+	return ids;
+}
+
+function mapRecipe(
+	recipe: RecipeWithInputs,
+	method: 'refine' | 'cook' | 'craft'
+): ReverseRecipe | null {
+	const outputId = recipe.Output?.Id;
+	if (!outputId) return null;
+
+	const outputItem = getById(outputId);
+	if (!outputItem?.Name) return null;
+
+	return {
+		method,
+		outputId,
+		outputName: outputItem.Name,
+		outputIcon: outputItem.Icon ?? '',
+		outputUrl: getSlug(outputItem),
+		outputQuantity: recipe.Output?.Quantity ?? 1,
+		inputs: recipe.Inputs.map((input) => {
+			const inputItem = getById(input.Id);
+			return {
+				id: input.Id,
+				name: inputItem?.Name ?? input.Id,
+				icon: inputItem?.Icon ?? '',
+				quantity: input.Quantity,
+			};
+		}),
+	};
+}
+
+function buildEntry(inputId: string): ReverseEntry {
+	const item = getById(inputId);
+	const recipes: ReverseRecipe[] = [];
+
+	for (const recipe of findInputFromRefiner(inputId) as unknown as RecipeWithInputs[]) {
+		const mapped = mapRecipe(recipe, 'refine');
+		if (mapped) recipes.push(mapped);
+	}
+
+	for (const recipe of findInputFromCooking(inputId) as unknown as RecipeWithInputs[]) {
+		const mapped = mapRecipe(recipe, 'cook');
+		if (mapped) recipes.push(mapped);
+	}
+
+	for (const recipe of findInputFromCrafting(inputId) as unknown as RecipeWithInputs[]) {
+		const mapped = mapRecipe(recipe, 'craft');
+		if (mapped) recipes.push(mapped);
+	}
+
+	recipes.sort((a, b) => a.outputName.localeCompare(b.outputName));
+
+	return {
+		id: inputId,
+		name: item?.Name ?? inputId,
+		icon: item?.Icon ?? '',
+		recipes,
+	};
+}
+
+const body: ReverseEntry[] = Array.from(collectInputIds())
+	.map((inputId) => buildEntry(inputId))
+	.sort((a, b) => a.name.localeCompare(b.name));
+
+export const GET: APIRoute = () => {
+	return new Response(JSON.stringify({ body }), {
+		headers: {
+			'Content-Type': 'application/json',
+			'Cache-Control': 'public, max-age=300',
+		},
+	});
+};

--- a/src/pages/calculator/reverse.astro
+++ b/src/pages/calculator/reverse.astro
@@ -52,11 +52,11 @@ const imageBaseUrl = SITE.imageBaseUrl;
 				type="text"
 				autocomplete="off"
 				placeholder="Search ingredients (e.g. Ferrite Dust, Carbon)…"
-				class="h-12 w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+				class="box-border h-12 w-full max-w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
 			/>
 			<div
 				id="item-results"
-				class="mt-2 max-h-64 overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
+				class="box-border mt-2 max-h-64 max-w-full overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
 				role="listbox"
 				aria-label="Matching ingredients"
 			></div>

--- a/src/pages/calculator/reverse.astro
+++ b/src/pages/calculator/reverse.astro
@@ -1,0 +1,557 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Breadcrumbs from '@components/Breadcrumbs.astro';
+import { getSiteOrigin } from '@utils/structuredData.js';
+import { SITE } from '@config';
+
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const canonicalUrl = new URL('/calculator/reverse', siteOrigin).toString();
+const title = "Reverse Calculator — What Can I Make? | No Man's Sky Recipes";
+const description =
+	'Pick a raw material or ingredient and see everything you can refine, cook, or craft with it.';
+const breadcrumbs = [
+	{ name: 'Home', href: '/' },
+	{ name: 'Crafting Calculator', href: '/calculator' },
+	{ name: 'Reverse Calculator' },
+];
+const breadcrumbSchema = {
+	'@context': 'https://schema.org',
+	'@type': 'BreadcrumbList',
+	'@id': `${canonicalUrl}#breadcrumb`,
+	itemListElement: [
+		{ '@type': 'ListItem', position: 1, name: 'Home', item: `${siteOrigin}/` },
+		{ '@type': 'ListItem', position: 2, name: 'Crafting Calculator', item: `${siteOrigin}/calculator` },
+		{ '@type': 'ListItem', position: 3, name: 'Reverse Calculator', item: canonicalUrl },
+	],
+};
+const imageBaseUrl = SITE.imageBaseUrl;
+---
+
+<Layout
+	{title}
+	{description}
+	slug="calculator"
+	structuredData={breadcrumbSchema}
+	ogImage={`${SITE.website}/images/calculator.webp`}
+>
+	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
+	<h1 class="text-center text-4xl sm:text-6xl mt-2">Reverse Calculator</h1>
+	<p class="mx-auto mb-8 mt-3 max-w-3xl text-center text-sky-200/90">
+		Pick an ingredient or raw material to see every recipe that uses it — refining, cooking, and crafting — with optional yield estimates when you have a set amount on hand.
+	</p>
+
+	<div
+		id="reverse-app"
+		class="mx-auto max-w-4xl px-4 pb-12"
+		data-image-base={imageBaseUrl}
+	>
+		<div class="mb-6">
+			<label for="item-search" class="sr-only">Search ingredients</label>
+			<input
+				id="item-search"
+				type="text"
+				autocomplete="off"
+				placeholder="Search ingredients (e.g. Ferrite Dust, Carbon)…"
+				class="h-12 w-full rounded-sm border border-sky-700 bg-sky-900/50 px-4 text-white placeholder-sky-400 focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+			/>
+			<div
+				id="item-results"
+				class="mt-2 max-h-64 overflow-y-auto rounded-sm border border-sky-800 bg-black/40 hidden"
+				role="listbox"
+				aria-label="Matching ingredients"
+			></div>
+		</div>
+
+		<div id="selected-item" class="mb-6 hidden"></div>
+
+		<div class="mb-6 flex flex-wrap items-center gap-4">
+			<label for="have-qty" class="text-sm text-sky-200">I have</label>
+			<input
+				id="have-qty"
+				type="number"
+				min="1"
+				value="1"
+				class="h-10 w-24 rounded-sm border border-sky-700 bg-sky-900/50 px-3 text-white focus:border-sky-400 focus:outline-hidden focus:ring-1 focus:ring-sky-400"
+			/>
+			<span id="have-label" class="text-sm text-sky-200/80">of the selected item</span>
+		</div>
+
+		<div class="mb-4 flex flex-wrap gap-2">
+			<div class="inline-flex">
+				<input type="checkbox" class="peer hidden" name="method-filter" id="filter-refine" value="refine" checked tabindex="-1" />
+				<label for="filter-refine" class="select-none cursor-pointer rounded-lg border-2 border-sky-600 py-0.5 px-2 text-sm text-white transition-colors duration-200 ease-in-out peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
+					Refine
+				</label>
+			</div>
+			<div class="inline-flex">
+				<input type="checkbox" class="peer hidden" name="method-filter" id="filter-cook" value="cook" checked tabindex="-1" />
+				<label for="filter-cook" class="select-none cursor-pointer rounded-lg border-2 border-sky-600 py-0.5 px-2 text-sm text-white transition-colors duration-200 ease-in-out peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
+					Cook
+				</label>
+			</div>
+			<div class="inline-flex">
+				<input type="checkbox" class="peer hidden" name="method-filter" id="filter-craft" value="craft" checked tabindex="-1" />
+				<label for="filter-craft" class="select-none cursor-pointer rounded-lg border-2 border-sky-600 py-0.5 px-2 text-sm text-white transition-colors duration-200 ease-in-out peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
+					Craft
+				</label>
+			</div>
+		</div>
+
+		<section aria-labelledby="results-heading">
+			<h2 id="results-heading" class="sr-only">Recipe results</h2>
+			<div id="results-empty" class="text-sky-200/70 text-sm">
+				Search above and select an ingredient to see what you can make with it.
+			</div>
+			<div id="results-no-recipes" class="text-sky-200/70 text-sm hidden">
+				No recipes use this item.
+			</div>
+			<div id="results-list" class="hidden"></div>
+		</section>
+	</div>
+</Layout>
+
+<script>
+	type ReverseRecipeInput = {
+		id: string;
+		name: string;
+		icon: string;
+		quantity: number;
+	};
+
+	type ReverseRecipe = {
+		method: 'refine' | 'cook' | 'craft';
+		outputId: string;
+		outputName: string;
+		outputIcon: string;
+		outputUrl: string;
+		outputQuantity: number;
+		inputs: ReverseRecipeInput[];
+	};
+
+	type ReverseEntry = {
+		id: string;
+		name: string;
+		icon: string;
+		recipes: ReverseRecipe[];
+	};
+
+	const METHOD_LABELS: Record<ReverseRecipe['method'], string> = {
+		refine: 'Refine',
+		cook: 'Cook',
+		craft: 'Craft',
+	};
+
+	const reverseApp = document.getElementById('reverse-app');
+	const itemSearch = document.getElementById('item-search') as HTMLInputElement | null;
+	const itemResults = document.getElementById('item-results');
+	const selectedItemEl = document.getElementById('selected-item');
+	const haveQtyInput = document.getElementById('have-qty') as HTMLInputElement | null;
+	const haveLabel = document.getElementById('have-label');
+	const resultsEmpty = document.getElementById('results-empty');
+	const resultsNoRecipes = document.getElementById('results-no-recipes');
+	const resultsList = document.getElementById('results-list');
+	const methodCheckboxes = Array.from(
+		document.querySelectorAll<HTMLInputElement>('input[name="method-filter"]')
+	);
+
+	const imageBaseUrl = reverseApp?.dataset.imageBase ?? '/images/items/';
+
+	let entries: ReverseEntry[] = [];
+	const entriesById = new Map<string, ReverseEntry>();
+	let selectedEntry: ReverseEntry | null = null;
+	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let urlDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let datasetPromise: Promise<ReverseEntry[]> | null = null;
+
+	function loadReverseDataset(): Promise<ReverseEntry[]> {
+		if (!datasetPromise) {
+			datasetPromise = fetch('/calculator/reverse-data.json', { cache: 'force-cache' })
+				.then((response) => response.json())
+				.then((results) => {
+					if (!results || !Array.isArray(results.body)) {
+						return [];
+					}
+					return results.body.filter(
+						(entry: ReverseEntry) =>
+							entry &&
+							typeof entry.id === 'string' &&
+							typeof entry.name === 'string' &&
+							Array.isArray(entry.recipes)
+					);
+				})
+				.catch((error) => {
+					datasetPromise = null;
+					throw error;
+				});
+		}
+		return datasetPromise;
+	}
+
+	function getHaveQty(): number {
+		const parsed = Number.parseInt(haveQtyInput?.value ?? '1', 10);
+		return Number.isFinite(parsed) && parsed >= 1 ? parsed : 1;
+	}
+
+	function getSelectedMethods(): Set<ReverseRecipe['method']> {
+		const selected = methodCheckboxes
+			.filter((checkbox) => checkbox.checked)
+			.map((checkbox) => checkbox.value as ReverseRecipe['method']);
+		return new Set(selected);
+	}
+
+	function updateUrl() {
+		if (urlDebounceTimer) {
+			clearTimeout(urlDebounceTimer);
+		}
+		urlDebounceTimer = setTimeout(() => {
+			const params = new URLSearchParams();
+			if (selectedEntry) {
+				params.set('item', selectedEntry.id);
+				const haveQty = getHaveQty();
+				if (haveQty > 1) {
+					params.set('have', String(haveQty));
+				}
+			}
+			const query = params.toString();
+			const newUrl = `/calculator/reverse${query ? `?${query}` : ''}`;
+			window.history.replaceState({}, '', newUrl);
+		}, 200);
+	}
+
+	function parseUrlState(): { itemId: string | null; haveQty: number } {
+		const params = new URLSearchParams(window.location.search);
+		const itemId = params.get('item');
+		const haveParam = params.get('have');
+		let haveQty = 1;
+		if (haveParam) {
+			const parsed = Number.parseInt(haveParam, 10);
+			if (Number.isFinite(parsed) && parsed >= 1) {
+				haveQty = parsed;
+			}
+		}
+		return { itemId, haveQty };
+	}
+
+	function selectEntry(entry: ReverseEntry) {
+		selectedEntry = entry;
+		if (itemSearch) {
+			itemSearch.value = entry.name;
+		}
+		if (itemResults) {
+			itemResults.classList.add('hidden');
+			itemResults.textContent = '';
+		}
+		renderSelectedItem();
+		renderResults();
+		updateUrl();
+	}
+
+	function renderSelectedItem() {
+		if (!selectedItemEl || !haveLabel) return;
+
+		selectedItemEl.textContent = '';
+
+		if (!selectedEntry) {
+			selectedItemEl.classList.add('hidden');
+			haveLabel.textContent = 'of the selected item';
+			return;
+		}
+
+		selectedItemEl.classList.remove('hidden');
+
+		const row = document.createElement('div');
+		row.className = 'flex items-center gap-3 rounded-sm border border-sky-800 bg-sky-900/30 px-4 py-3';
+
+		if (selectedEntry.icon) {
+			const img = document.createElement('img');
+			img.src = `${imageBaseUrl}${selectedEntry.icon}`;
+			img.alt = '';
+			img.className = 'h-8 w-8 shrink-0 object-contain';
+			img.loading = 'lazy';
+			row.appendChild(img);
+		}
+
+		const nameSpan = document.createElement('span');
+		nameSpan.className = 'text-lg font-medium text-white';
+		nameSpan.textContent = selectedEntry.name;
+		row.appendChild(nameSpan);
+
+		selectedItemEl.appendChild(row);
+		haveLabel.textContent = `of ${selectedEntry.name}`;
+	}
+
+	function createInputChip(input: ReverseRecipeInput): HTMLSpanElement {
+		const chip = document.createElement('span');
+		chip.className = 'inline-flex items-center gap-1 text-sm text-sky-200/90';
+
+		if (input.icon) {
+			const img = document.createElement('img');
+			img.src = `${imageBaseUrl}${input.icon}`;
+			img.alt = '';
+			img.className = 'h-5 w-5 shrink-0 object-contain';
+			img.loading = 'lazy';
+			chip.appendChild(img);
+		}
+
+		const qtySpan = document.createElement('span');
+		qtySpan.className = 'tabular-nums text-sky-300';
+		qtySpan.textContent = String(input.quantity);
+		chip.appendChild(qtySpan);
+
+		const nameSpan = document.createElement('span');
+		nameSpan.textContent = input.name;
+		chip.appendChild(nameSpan);
+
+		return chip;
+	}
+
+	function createRecipeRow(recipe: ReverseRecipe, haveQty: number): HTMLLIElement {
+		const li = document.createElement('li');
+		li.className = 'flex flex-col gap-2 border-b border-sky-800/60 py-3 last:border-b-0 sm:flex-row sm:items-center sm:gap-4';
+
+		const outputLink = document.createElement('a');
+		outputLink.href = recipe.outputUrl;
+		outputLink.className = 'flex min-w-0 flex-1 items-center gap-2 text-cyan-300 hover:text-cyan-200';
+
+		if (recipe.outputIcon) {
+			const img = document.createElement('img');
+			img.src = `${imageBaseUrl}${recipe.outputIcon}`;
+			img.alt = '';
+			img.className = 'h-7 w-7 shrink-0 object-contain';
+			img.loading = 'lazy';
+			outputLink.appendChild(img);
+		}
+
+		const outputName = document.createElement('span');
+		outputName.className = 'font-medium';
+		outputName.textContent = recipe.outputName;
+		outputLink.appendChild(outputName);
+
+		li.appendChild(outputLink);
+
+		const inputsWrap = document.createElement('div');
+		inputsWrap.className = 'flex flex-wrap items-center gap-2 text-sm';
+		const inputsLabel = document.createElement('span');
+		inputsLabel.className = 'text-sky-400';
+		inputsLabel.textContent = 'Needs:';
+		inputsWrap.appendChild(inputsLabel);
+
+		for (const input of recipe.inputs) {
+			inputsWrap.appendChild(createInputChip(input));
+		}
+		li.appendChild(inputsWrap);
+
+		const outputQtyWrap = document.createElement('div');
+		outputQtyWrap.className = 'text-sm text-sky-200/90 shrink-0';
+
+		const outputQtyText = document.createElement('span');
+		outputQtyText.textContent = `→ ${recipe.outputQuantity} ${recipe.outputName}`;
+		outputQtyWrap.appendChild(outputQtyText);
+
+		if (selectedEntry) {
+			const selectedInput = recipe.inputs.find((input) => input.id === selectedEntry?.id);
+			if (selectedInput && selectedInput.quantity > 0) {
+				const maxYield = Math.floor(haveQty / selectedInput.quantity) * recipe.outputQuantity;
+				const yieldSpan = document.createElement('span');
+				yieldSpan.className = 'ml-2 text-cyan-300';
+				yieldSpan.textContent = `(up to ${maxYield.toLocaleString()} ${recipe.outputName})`;
+				outputQtyWrap.appendChild(yieldSpan);
+			}
+		}
+
+		li.appendChild(outputQtyWrap);
+
+		return li;
+	}
+
+	function renderResults() {
+		if (!resultsEmpty || !resultsNoRecipes || !resultsList) return;
+
+		resultsEmpty.classList.add('hidden');
+		resultsNoRecipes.classList.add('hidden');
+		resultsList.classList.add('hidden');
+		resultsList.textContent = '';
+
+		if (!selectedEntry) {
+			resultsEmpty.classList.remove('hidden');
+			return;
+		}
+
+		const selectedMethods = getSelectedMethods();
+		const haveQty = getHaveQty();
+		const grouped = new Map<ReverseRecipe['method'], ReverseRecipe[]>();
+
+		for (const recipe of selectedEntry.recipes) {
+			if (!selectedMethods.has(recipe.method)) continue;
+			const list = grouped.get(recipe.method) ?? [];
+			list.push(recipe);
+			grouped.set(recipe.method, list);
+		}
+
+		const methodOrder: ReverseRecipe['method'][] = ['refine', 'cook', 'craft'];
+		let hasAny = false;
+
+		for (const method of methodOrder) {
+			const recipes = grouped.get(method);
+			if (!recipes || recipes.length === 0) continue;
+
+			hasAny = true;
+			const section = document.createElement('section');
+			section.className = 'mb-8';
+			section.setAttribute('aria-labelledby', `method-${method}`);
+
+			const heading = document.createElement('h3');
+			heading.id = `method-${method}`;
+			heading.className = 'text-2xl mb-3 text-cyan-200';
+			heading.textContent = METHOD_LABELS[method];
+			section.appendChild(heading);
+
+			const ul = document.createElement('ul');
+			ul.className = 'm-0 list-none p-0';
+			for (const recipe of recipes) {
+				ul.appendChild(createRecipeRow(recipe, haveQty));
+			}
+			section.appendChild(ul);
+
+			resultsList.appendChild(section);
+		}
+
+		if (!hasAny) {
+			if (selectedEntry.recipes.length === 0) {
+				resultsNoRecipes.classList.remove('hidden');
+			} else {
+				resultsNoRecipes.textContent = 'No recipes match the selected methods.';
+				resultsNoRecipes.classList.remove('hidden');
+			}
+			return;
+		}
+
+		resultsList.classList.remove('hidden');
+	}
+
+	function renderItemSearch() {
+		if (!itemSearch || !itemResults) return;
+
+		const term = itemSearch.value.trim().toLowerCase();
+		itemResults.textContent = '';
+
+		if (!term) {
+			itemResults.classList.add('hidden');
+			return;
+		}
+
+		const matches = entries
+			.filter((entry) => entry.name.toLowerCase().includes(term))
+			.sort((a, b) => {
+				const aName = a.name.toLowerCase();
+				const bName = b.name.toLowerCase();
+				if (aName === term) return -1;
+				if (bName === term) return 1;
+				if (aName.startsWith(term) && !bName.startsWith(term)) return -1;
+				if (bName.startsWith(term) && !aName.startsWith(term)) return 1;
+				return a.name.localeCompare(b.name);
+			})
+			.slice(0, 50);
+
+		if (matches.length === 0) {
+			itemResults.classList.remove('hidden');
+			const empty = document.createElement('p');
+			empty.className = 'p-3 text-sm text-sky-200/70';
+			empty.textContent = 'No matching ingredients found.';
+			itemResults.appendChild(empty);
+			return;
+		}
+
+		itemResults.classList.remove('hidden');
+		const ul = document.createElement('ul');
+		ul.className = 'm-0 list-none p-0';
+
+		for (const entry of matches) {
+			const li = document.createElement('li');
+			li.setAttribute('role', 'option');
+
+			const btn = document.createElement('button');
+			btn.type = 'button';
+			btn.className =
+				'flex w-full items-center gap-2 px-3 py-2 text-left text-white hover:bg-sky-800/60';
+
+			if (entry.icon) {
+				const img = document.createElement('img');
+				img.src = `${imageBaseUrl}${entry.icon}`;
+				img.alt = '';
+				img.className = 'h-6 w-6 shrink-0 object-contain';
+				img.loading = 'lazy';
+				btn.appendChild(img);
+			}
+
+			const nameSpan = document.createElement('span');
+			nameSpan.textContent = entry.name;
+			btn.appendChild(nameSpan);
+
+			if (entry.recipes.length > 0) {
+				const countBadge = document.createElement('span');
+				countBadge.className = 'ml-auto text-xs text-sky-400';
+				countBadge.textContent = `${entry.recipes.length} recipe${entry.recipes.length === 1 ? '' : 's'}`;
+				btn.appendChild(countBadge);
+			}
+
+			btn.addEventListener('click', () => selectEntry(entry));
+
+			li.appendChild(btn);
+			ul.appendChild(li);
+		}
+
+		itemResults.appendChild(ul);
+	}
+
+	async function init() {
+		try {
+			entries = await loadReverseDataset();
+			entriesById.clear();
+			for (const entry of entries) {
+				entriesById.set(entry.id, entry);
+			}
+
+			const { itemId, haveQty } = parseUrlState();
+			if (haveQtyInput) {
+				haveQtyInput.value = String(haveQty);
+			}
+
+			if (itemId) {
+				const entry = entriesById.get(itemId);
+				if (entry) {
+					selectEntry(entry);
+				}
+			}
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error('Failed to load reverse calculator data:', error);
+			}
+			if (resultsEmpty) {
+				resultsEmpty.textContent = 'Unable to load recipe data. Please refresh the page.';
+			}
+		}
+	}
+
+	if (itemSearch) {
+		itemSearch.addEventListener('input', () => {
+			if (searchDebounceTimer) {
+				clearTimeout(searchDebounceTimer);
+			}
+			searchDebounceTimer = setTimeout(renderItemSearch, 200);
+		});
+	}
+
+	if (haveQtyInput) {
+		haveQtyInput.addEventListener('input', () => {
+			renderResults();
+			updateUrl();
+		});
+	}
+
+	methodCheckboxes.forEach((checkbox) => {
+		checkbox.addEventListener('change', renderResults);
+	});
+
+	init();
+</script>


### PR DESCRIPTION
Two new interactive calculator tools, both fed by build-time JSON endpoints that reuse the recipe engine extracted in #74 (no recursive traversal in the browser).

## #1 — Crafting Planner (`/calculator/planner`)
Players building bases/farms can total raw materials across MULTIPLE products.
- `planner-data.json.ts`: flattens each of the 68 craftable products to per-unit raw materials via `recipeTree.createArray`.
- Pick products + quantities → live merged/summed raw-material totals (sorted desc), per-item breakdown toggle.
- **Shareable** `?items=ID:qty,ID:qty` URL (round-trips on load) + Copy link button.

## #36 — Reverse Calculator (`/calculator/reverse`)
The inverse: "I have X — what can I make?"
- `reverse-data.json.ts`: indexes every input item → recipes that use it (refine/cook/craft) via the `findInputFrom*` helpers in lookup.ts.
- Pick an ingredient → results grouped Refine / Cook / Craft, each linking to the product page.
- **"I have N"** max-yield math: `floor(N / inputQty) × outputQty`.
- Shareable `?item=ID&have=N` URL.

Both linked from the calculator landing page. DOM-only rendering (no interpolated innerHTML), icons from `data-image-base`.

## Verified independently
- type-check ✓, lint ✓ (only pre-existing `index.astro` no-useless-escape, untouched), build ✓ **5,096 pages** (+2).
- Endpoint data checked vs baseline: planner 68 products (Stasis Device flattens correctly); reverse 529 input items (Ferrite Dust → 215 craft + 44 refine).
- **Live browser tests** on `astro preview`:
  - Planner: Stasis ×5 + Living Glass ×10 → Frost Crystal 3,500 / Sulphurine 2,500 / Gamma Root 6,000 (math correct); `?items=` URL preload works; Copy link enabled.
  - Reverse: `?item=LAND1&have=1000` preloads Ferrite Dust; yields correct (Ammonia up to 1,000; Dirty Bronze up to 8 = floor(1000/120)).

## Note
The site-wide floating search button slightly overlaps content bottom-right — pre-existing global FAB, not introduced here.