### PR TITLE
fix(item): remove section jump-nav, tighten pill spacing

### DIFF
--- a/src/components/item/ItemDetails.astro
+++ b/src/components/item/ItemDetails.astro
@@ -150,7 +150,7 @@ const {
     </p>
 
     {showBlueprintCost && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         <p class="inline-flex items-center gap-2 rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
           <img
             src={blueprintIcon}
@@ -167,7 +167,7 @@ const {
     )}
 
     {isCorvettePage && corvetteAttributes.length > 0 && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {corvetteAttributes.map((attribute) => (
           <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             {attribute.label}: {attribute.value}
@@ -177,7 +177,7 @@ const {
     )}
 
     {isCorvettePage && shipTechId && (
-      <div class="mt-4">
+      <div class="mt-2">
         <p class="inline-flex items-center gap-2 rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
           Ship Tech:
           <a href={getSlug(shipTechId)} class="text-cyan-300 hover:text-cyan-200">
@@ -188,7 +188,7 @@ const {
     )}
 
     {deploysIntoId && (
-      <div class="mt-4">
+      <div class="mt-2">
         <p class="inline-flex items-center gap-2 rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
           Installs as:
           <a href={getSlug(deploysIntoId)} class="text-cyan-300 hover:text-cyan-200">
@@ -199,7 +199,7 @@ const {
     )}
 
     {acquisitionPills.length > 0 && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {acquisitionPills.map((pill) => (
           <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             {pill.label}: {pill.value}
@@ -209,7 +209,7 @@ const {
     )}
 
     {isFoodItem && (foodEffectCategory || foodEffectLines.length > 0) && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {foodEffectCategory && (
           <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             Effect: {foodEffectCategory}
@@ -225,7 +225,7 @@ const {
     )}
 
     {isBuildingPage && buildingPlacementPills.length > 0 && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {buildingPlacementPills.map((pill) => (
           <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             {pill.label}: {pill.value}
@@ -235,7 +235,7 @@ const {
     )}
 
     {isExocraftPage && exocraftPills.length > 0 && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {exocraftPills.map((pill) => (
           <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             {pill.label}: {pill.value}
@@ -245,7 +245,7 @@ const {
     )}
 
     {isFishPage && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {fishingTimeLabel && (
           <p class="inline-flex items-center gap-2 rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
             {showSunIcon && (
@@ -306,7 +306,7 @@ const {
     )}
 
     {plantGrowTime && (
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         <p class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200">
           {growTimeHeader}: {plantGrowTime}
         </p>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -425,16 +425,6 @@ const acquisitionPills = [
     : undefined,
 ].filter((pill): pill is { label: string; value: string } => Boolean(pill));
 
-const pageSections = [
-  data.length > 0 ? { id: 'crafting', label: isFoodItem ? 'Cooking' : 'Crafting' } : null,
-  outputRefined.length > 0 ? { id: 'refining', label: 'Refining' } : null,
-  outputCooked.length > 0 ? { id: 'cooking', label: 'Nutrient Processor' } : null,
-  groupedInputRefined.length > 0 ? { id: 'refined-to-create', label: 'Refined from' } : null,
-  groupedInputCooked.length > 0 ? { id: 'cooked-to-create', label: 'Cooked from' } : null,
-  groupedInputCrafting.length > 0 ? { id: 'used-to-create', label: 'Used to craft' } : null,
-  faqQuestions.length > 0 ? { id: 'faq', label: 'FAQ' } : null,
-].filter((section): section is { id: string; label: string } => section !== null);
-
 const showStatsSection =
   (isUpgradePage || isTechnologyPage) && upgradeStats.length > 0;
 const imageBaseUrl = SITE.imageBaseUrl;
@@ -450,18 +440,6 @@ const imageBaseUrl = SITE.imageBaseUrl;
     ]}
   />
   {itemUpdateMeta && <UpdateChangesPanel meta={itemUpdateMeta} />}
-  {pageSections.length > 1 && (
-    <nav aria-label="Page sections" class="mb-4 flex flex-wrap gap-2">
-      {pageSections.map((section) => (
-        <a
-          href={`#${section.id}`}
-          class="rounded-sm bg-gray-700 px-3 py-1 text-sm text-cyan-200 hover:bg-gray-600 hover:text-cyan-100 transition-colors"
-        >
-          {section.label}
-        </a>
-      ))}
-    </nav>
-  )}
   <ItemDetails
     item={item}
     answerSummary={answerSummary}


### PR DESCRIPTION
## Changes

From mobile UI feedback on item detail pages:

1. **Removed the in-page section jump-nav** (the Crafting / FAQ / etc. links rendered under the breadcrumb). Also dropped the now-unused `pageSections` const in `Page.astro`.
2. **Tightened pill row spacing** — reduced the vertical gap between pill groups (Max Stack/Rarity/Legality, Planet Base/Freighter/Space Base/Group/Sub-group, etc.) from `mt-4` (16px) to `mt-2` (8px) for a more compact layout.

## Verification
- `pnpm run type-check` ✅
- `pnpm run build` ✅ (5,096 pages)
- Confirmed in built output: section nav gone, pill rows now `mt-2`
- Visual confirm on preview server