### PR TITLE
feat(reverse-calc): redesign results to lead with the yield

### DIFF
--- a/src/pages/calculator/index.astro
+++ b/src/pages/calculator/index.astro
@@ -62,21 +62,6 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Calculator</h1>
 	<p class="mx-auto mb-4 mt-3 max-w-3xl text-center text-sky-200/90">{intro}</p>
-	<p class="text-center mb-6 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
-		<a
-			href="/calculator/planner"
-			class="text-lg font-medium text-cyan-300 underline-offset-2 hover:text-cyan-200 hover:underline"
-		>
-			Try the multi-item Crafting Planner →
-		</a>
-		<span class="hidden text-sky-600 sm:inline" aria-hidden="true">·</span>
-		<a
-			href="/calculator/reverse"
-			class="text-lg font-medium text-cyan-300 underline-offset-2 hover:text-cyan-200 hover:underline"
-		>
-			What can I make with an item? Reverse Calculator →
-		</a>
-	</p>
 	<p class="text-xl text-center mt-3 mb-8">Choose an item below to start</p>
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
 		{

--- a/src/pages/calculator/reverse.astro
+++ b/src/pages/calculator/reverse.astro
@@ -280,86 +280,56 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		haveLabel.textContent = `of ${selectedEntry.name}`;
 	}
 
-	function createInputChip(input: ReverseRecipeInput): HTMLSpanElement {
-		const chip = document.createElement('span');
-		chip.className = 'inline-flex items-center gap-1 text-sm text-sky-200/90';
-
-		if (input.icon) {
-			const img = document.createElement('img');
-			img.src = `${imageBaseUrl}${input.icon}`;
-			img.alt = '';
-			img.className = 'h-5 w-5 shrink-0 object-contain';
-			img.loading = 'lazy';
-			chip.appendChild(img);
-		}
-
-		const qtySpan = document.createElement('span');
-		qtySpan.className = 'tabular-nums text-sky-300';
-		qtySpan.textContent = String(input.quantity);
-		chip.appendChild(qtySpan);
-
-		const nameSpan = document.createElement('span');
-		nameSpan.textContent = input.name;
-		chip.appendChild(nameSpan);
-
-		return chip;
-	}
-
 	function createRecipeRow(recipe: ReverseRecipe, haveQty: number): HTMLLIElement {
 		const li = document.createElement('li');
-		li.className = 'flex flex-col gap-2 border-b border-sky-800/60 py-3 last:border-b-0 sm:flex-row sm:items-center sm:gap-4';
+		li.className = 'flex items-center gap-3 border-b border-sky-800/40 py-3 last:border-b-0';
 
-		const outputLink = document.createElement('a');
-		outputLink.href = recipe.outputUrl;
-		outputLink.className = 'flex min-w-0 flex-1 items-center gap-2 text-cyan-300 hover:text-cyan-200';
-
+		// Output icon
 		if (recipe.outputIcon) {
 			const img = document.createElement('img');
 			img.src = `${imageBaseUrl}${recipe.outputIcon}`;
 			img.alt = '';
-			img.className = 'h-7 w-7 shrink-0 object-contain';
+			img.className = 'h-9 w-9 shrink-0 object-contain';
 			img.loading = 'lazy';
-			outputLink.appendChild(img);
+			li.appendChild(img);
 		}
 
-		const outputName = document.createElement('span');
-		outputName.className = 'font-medium';
-		outputName.textContent = recipe.outputName;
-		outputLink.appendChild(outputName);
+		const body = document.createElement('div');
+		body.className = 'min-w-0 flex-1';
 
-		li.appendChild(outputLink);
+		// Headline: the yield is the answer
+		const headline = document.createElement('a');
+		headline.href = recipe.outputUrl;
+		headline.className = 'block text-lg font-bold leading-tight text-cyan-300 hover:text-cyan-200';
 
-		const inputsWrap = document.createElement('div');
-		inputsWrap.className = 'flex flex-wrap items-center gap-2 text-sm';
-		const inputsLabel = document.createElement('span');
-		inputsLabel.className = 'text-sky-400';
-		inputsLabel.textContent = 'Needs:';
-		inputsWrap.appendChild(inputsLabel);
-
-		for (const input of recipe.inputs) {
-			inputsWrap.appendChild(createInputChip(input));
-		}
-		li.appendChild(inputsWrap);
-
-		const outputQtyWrap = document.createElement('div');
-		outputQtyWrap.className = 'text-sm text-sky-200/90 shrink-0';
-
-		const outputQtyText = document.createElement('span');
-		outputQtyText.textContent = `→ ${recipe.outputQuantity} ${recipe.outputName}`;
-		outputQtyWrap.appendChild(outputQtyText);
-
-		if (selectedEntry) {
-			const selectedInput = recipe.inputs.find((input) => input.id === selectedEntry?.id);
-			if (selectedInput && selectedInput.quantity > 0) {
-				const maxYield = Math.floor(haveQty / selectedInput.quantity) * recipe.outputQuantity;
-				const yieldSpan = document.createElement('span');
-				yieldSpan.className = 'ml-2 text-cyan-300';
-				yieldSpan.textContent = `(up to ${maxYield.toLocaleString()} ${recipe.outputName})`;
-				outputQtyWrap.appendChild(yieldSpan);
+		let headlineQty = recipe.outputQuantity;
+		const selectedInput = selectedEntry
+			? recipe.inputs.find((input) => input.id === selectedEntry?.id)
+			: undefined;
+		if (selectedInput && selectedInput.quantity > 0) {
+			const maxYield = Math.floor(haveQty / selectedInput.quantity) * recipe.outputQuantity;
+			// Only override when you can make at least one batch; otherwise show the
+			// per-batch output so a row never reads "0".
+			if (maxYield >= 1) {
+				headlineQty = maxYield;
 			}
 		}
+		headline.textContent = `${headlineQty.toLocaleString()} ${recipe.outputName}`;
+		body.appendChild(headline);
 
-		li.appendChild(outputQtyWrap);
+		// Muted recipe line: from <inputs> · N per <method>
+		const recipeLine = document.createElement('p');
+		recipeLine.className = 'm-0 mt-0.5 text-xs leading-snug text-sky-300/80';
+		const inputsText = recipe.inputs
+			.map((input) => `${input.quantity} ${input.name}`)
+			.join(' + ');
+		const inputsStrong = document.createElement('span');
+		inputsStrong.className = 'text-sky-200';
+		inputsStrong.textContent = inputsText;
+		recipeLine.append('from ', inputsStrong, ` · ${recipe.outputQuantity} per ${recipe.method}`);
+		body.appendChild(recipeLine);
+
+		li.appendChild(body);
 
 		return li;
 	}


### PR DESCRIPTION
## Problem
The reverse calculator results were cluttered: each recipe was 3 stacked lines and repeated the output name **3 times** (title, `→` line, and the `(up to X)` parenthetical). The actual answer — how many you can make — was buried at the end of line 3. With 'I have' defaulting to 1, many rows read `up to 0`, which looked broken.

## Redesign
- **Yield is the headline** — big cyan number + name, linking to the item page
- Recipe collapses to **one muted line**: `from <inputs> · N per <method>`
- Removed the `Needs:` label, the `→` line, and the `(up to X)` parenthetical
- When you can't make a full batch (e.g. have 1), headline falls back to the per-batch output so a row never reads 0
- Output name appears **once** per card instead of three times
- Method = section heading (Refine / Cook / Craft), not repeated per row
- Dropped the now-unused `createInputChip` helper
- Also removed the two redundant calculator links on `/calculator` (now in the Calculators sidebar dropdown)

## Verification
- `pnpm run type-check` ✅
- `pnpm run build` ✅ (5,096 pages)
- Live-tested with real data (Ammonia, have 100): yields correct (e.g. `3 Herox` = floor(100/30)×1), grouped by method, no overflow