### PR TITLE
Fix crafting planner breakdown and restore search on deploy

### DIFF
--- a/src/pages/calculator/planner-data.json.ts
+++ b/src/pages/calculator/planner-data.json.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import * as dataSources from '@datav2/index.js';
 import { createArray } from '@utils/recipeTree.js';
+import type { ProcessedItem } from '@utils/recipeTree.js';
 import { getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 
@@ -11,12 +12,21 @@ type PlannerItem = {
 	quantity: number;
 };
 
+type PlannerTreeItem = {
+	id: string;
+	name: string;
+	icon: string;
+	quantity: number;
+	url: string;
+	children: PlannerTreeItem[];
+};
+
 type PlannerProduct = {
 	id: string;
 	name: string;
 	icon: string;
 	url: string;
-	ingredients: PlannerItem[];
+	recipeTree: PlannerTreeItem[];
 	rawItems: PlannerItem[];
 };
 
@@ -39,22 +49,31 @@ const mapPlannerItem = (entry: { Id: string; Name: string; Icon: string; Quantit
 	quantity: entry.Quantity,
 });
 
+const mapTreeItem = (entry: ProcessedItem): PlannerTreeItem => ({
+	id: entry.Id,
+	name: entry.Name,
+	icon: entry.Icon,
+	quantity: entry.Quantity,
+	url: getSlug(entry.Id),
+	children: entry.RequiredItems.map(mapTreeItem),
+});
+
 const body: PlannerProduct[] = craftableItems
 	.map((item) => {
 		const { array, rawItems } = createArray(item, 1);
 		return {
 			item,
-			ingredients: array,
+			recipeTree: array,
 			rawItems,
 		};
 	})
 	.filter(({ rawItems }) => rawItems.length > 0)
-	.map(({ item, ingredients, rawItems }) => ({
+	.map(({ item, recipeTree, rawItems }) => ({
 		id: item.Id,
 		name: item.Name,
 		icon: item.Icon,
 		url: getSlug(item),
-		ingredients: ingredients.map(mapPlannerItem),
+		recipeTree: recipeTree.map(mapTreeItem),
 		rawItems: rawItems.map(mapPlannerItem),
 	}))
 	.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/pages/calculator/planner-data.json.ts
+++ b/src/pages/calculator/planner-data.json.ts
@@ -78,6 +78,8 @@ const body: PlannerProduct[] = craftableItems
 	}))
 	.sort((a, b) => a.name.localeCompare(b.name));
 
+export const prerender = true;
+
 export const GET: APIRoute = () => {
 	return new Response(JSON.stringify({ body }), {
 		headers: {

--- a/src/pages/calculator/planner-data.json.ts
+++ b/src/pages/calculator/planner-data.json.ts
@@ -4,7 +4,7 @@ import { createArray } from '@utils/recipeTree.js';
 import { getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 
-type PlannerRawItem = {
+type PlannerItem = {
 	id: string;
 	name: string;
 	icon: string;
@@ -16,7 +16,8 @@ type PlannerProduct = {
 	name: string;
 	icon: string;
 	url: string;
-	rawItems: PlannerRawItem[];
+	ingredients: PlannerItem[];
+	rawItems: PlannerItem[];
 };
 
 const allData = Object.values(dataSources).flatMap((source) =>
@@ -31,26 +32,30 @@ const craftableItems = allData.filter((item) => {
 	return true;
 });
 
+const mapPlannerItem = (entry: { Id: string; Name: string; Icon: string; Quantity: number }): PlannerItem => ({
+	id: entry.Id,
+	name: entry.Name,
+	icon: entry.Icon,
+	quantity: entry.Quantity,
+});
+
 const body: PlannerProduct[] = craftableItems
 	.map((item) => {
-		const { rawItems } = createArray(item, 1);
+		const { array, rawItems } = createArray(item, 1);
 		return {
 			item,
+			ingredients: array,
 			rawItems,
 		};
 	})
 	.filter(({ rawItems }) => rawItems.length > 0)
-	.map(({ item, rawItems }) => ({
+	.map(({ item, ingredients, rawItems }) => ({
 		id: item.Id,
 		name: item.Name,
 		icon: item.Icon,
 		url: getSlug(item),
-		rawItems: rawItems.map((rawItem) => ({
-			id: rawItem.Id,
-			name: rawItem.Name,
-			icon: rawItem.Icon,
-			quantity: rawItem.Quantity,
-		})),
+		ingredients: ingredients.map(mapPlannerItem),
+		rawItems: rawItems.map(mapPlannerItem),
 	}))
 	.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -104,7 +104,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 </Layout>
 
 <script>
-	type PlannerRawItem = {
+	type PlannerItem = {
 		id: string;
 		name: string;
 		icon: string;
@@ -116,7 +116,8 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		name: string;
 		icon: string;
 		url: string;
-		rawItems: PlannerRawItem[];
+		ingredients: PlannerItem[];
+		rawItems: PlannerItem[];
 	};
 
 	type PlanEntry = {
@@ -124,7 +125,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		qty: number;
 	};
 
-	type MergedRawItem = PlannerRawItem;
+	type MergedItem = PlannerItem;
 
 	const plannerApp = document.getElementById('planner-app');
 	const productSearch = document.getElementById('product-search') as HTMLInputElement | null;
@@ -159,6 +160,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 							entry &&
 							typeof entry.id === 'string' &&
 							typeof entry.name === 'string' &&
+							Array.isArray(entry.ingredients) &&
 							Array.isArray(entry.rawItems)
 					);
 				})
@@ -204,8 +206,8 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		}, 200);
 	}
 
-	function mergeRawItems(entries: PlanEntry[]): MergedRawItem[] {
-		const merged = new Map<string, MergedRawItem>();
+	function mergeRawItems(entries: PlanEntry[]): MergedItem[] {
+		const merged = new Map<string, MergedItem>();
 
 		for (const entry of entries) {
 			const product = productsById.get(entry.id);
@@ -230,13 +232,13 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		return Array.from(merged.values()).sort((a, b) => b.quantity - a.quantity);
 	}
 
-	function createRawItemRow(rawItem: MergedRawItem): HTMLLIElement {
+	function createItemRow(item: MergedItem): HTMLLIElement {
 		const li = document.createElement('li');
 		li.className = 'flex items-center gap-3 border-b border-sky-800/30 py-2 last:border-b-0';
 
-		if (rawItem.icon) {
+		if (item.icon) {
 			const img = document.createElement('img');
-			img.src = `${imageBaseUrl}${rawItem.icon}`;
+			img.src = `${imageBaseUrl}${item.icon}`;
 			img.alt = '';
 			img.className = 'h-7 w-7 shrink-0 object-contain';
 			img.loading = 'lazy';
@@ -245,12 +247,12 @@ const imageBaseUrl = SITE.imageBaseUrl;
 
 		const nameSpan = document.createElement('span');
 		nameSpan.className = 'min-w-0 flex-1 truncate text-sky-100';
-		nameSpan.textContent = rawItem.name;
+		nameSpan.textContent = item.name;
 		li.appendChild(nameSpan);
 
 		const qtySpan = document.createElement('span');
 		qtySpan.className = 'shrink-0 text-base font-bold tabular-nums text-cyan-300';
-		qtySpan.textContent = rawItem.quantity.toLocaleString();
+		qtySpan.textContent = item.quantity.toLocaleString();
 		li.appendChild(qtySpan);
 
 		return li;
@@ -274,7 +276,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		const ul = document.createElement('ul');
 		ul.className = 'm-0 flex list-none flex-col p-0';
 		for (const rawItem of merged) {
-			ul.appendChild(createRawItemRow(rawItem));
+			ul.appendChild(createItemRow(rawItem));
 		}
 		totalsList.appendChild(ul);
 
@@ -291,15 +293,15 @@ const imageBaseUrl = SITE.imageBaseUrl;
 
 				const itemUl = document.createElement('ul');
 				itemUl.className = 'm-0 flex list-none flex-col p-0 pl-2 border-l border-sky-800';
-				const scaled = product.rawItems
-					.map((rawItem) => ({
-						...rawItem,
-						quantity: rawItem.quantity * entry.qty,
+				const scaled = product.ingredients
+					.map((ingredient) => ({
+						...ingredient,
+						quantity: ingredient.quantity * entry.qty,
 					}))
 					.sort((a, b) => b.quantity - a.quantity);
 
-				for (const rawItem of scaled) {
-					itemUl.appendChild(createRawItemRow(rawItem));
+				for (const ingredient of scaled) {
+					itemUl.appendChild(createItemRow(ingredient));
 				}
 				breakdownSection.appendChild(itemUl);
 			}

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -332,27 +332,10 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		return li;
 	}
 
-	function scaleRecipeTree(items: PlannerTreeItem[], multiplier: number): PlannerTreeItem[] {
-		return items.map((item) => ({
-			...item,
-			quantity: item.quantity * multiplier,
-			children: scaleRecipeTree(item.children, multiplier),
-		}));
-	}
-
-	function createTreeQuantityBadge(quantity: number): HTMLSpanElement {
-		const qtySpan = document.createElement('span');
-		qtySpan.className =
-			'inline-flex min-w-7 shrink-0 items-center justify-center rounded-sm bg-sky-800/80 px-1.5 py-0.5 text-xs font-medium tabular-nums text-sky-200';
-		qtySpan.textContent = quantity.toLocaleString();
-		qtySpan.setAttribute('aria-label', `quantity ${quantity}`);
-		return qtySpan;
-	}
-
 	function createTreeNodeRow(item: PlannerTreeItem, isLeaf: boolean): HTMLElement {
 		const row = document.createElement(isLeaf ? 'a' : 'div');
 		row.className = isLeaf
-			? 'flex items-center gap-2 rounded-r py-1.5 pl-1 transition-colors hover:bg-cyan-500/10 border-l-2 border-cyan-500/40'
+			? 'flex items-center gap-2 rounded-r py-1.5 pl-1 transition-colors hover:bg-cyan-500/10'
 			: 'flex items-center gap-2 py-1.5 pl-1';
 
 		if (isLeaf) {
@@ -376,6 +359,15 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		row.appendChild(createTreeQuantityBadge(item.quantity));
 
 		return row;
+	}
+
+	function createTreeQuantityBadge(quantity: number): HTMLSpanElement {
+		const qtySpan = document.createElement('span');
+		qtySpan.className =
+			'inline-flex min-w-7 shrink-0 items-center justify-center rounded-sm bg-sky-800/80 px-1.5 py-0.5 text-xs font-medium tabular-nums text-sky-200';
+		qtySpan.textContent = quantity.toLocaleString();
+		qtySpan.setAttribute('aria-label', `quantity ${quantity}`);
+		return qtySpan;
 	}
 
 	function appendRecipeTree(container: HTMLElement, items: PlannerTreeItem[], parentQuantity = 1) {
@@ -464,7 +456,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 
 				const treeContainer = document.createElement('div');
 				treeContainer.className = 'ml-1';
-				appendRecipeTree(treeContainer, scaleRecipeTree(product.recipeTree, entry.qty));
+				appendRecipeTree(treeContainer, product.recipeTree, entry.qty);
 				productBlock.appendChild(treeContainer);
 				breakdownSection.appendChild(productBlock);
 			}

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -322,22 +322,24 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		return row;
 	}
 
-	function appendRecipeTree(container: HTMLElement, items: PlannerTreeItem[]) {
+	function appendRecipeTree(container: HTMLElement, items: PlannerTreeItem[], parentQuantity = 1) {
 		const list = document.createElement('ul');
 		list.className = 'm-0 list-none p-0';
 
 		for (const item of items) {
+			const displayQuantity = item.quantity * parentQuantity;
+			const displayItem = { ...item, quantity: displayQuantity };
 			const listItem = document.createElement('li');
 
 			if (item.children.length > 0) {
-				listItem.appendChild(createTreeNodeRow(item, false));
+				listItem.appendChild(createTreeNodeRow(displayItem, false));
 
 				const childContainer = document.createElement('div');
 				childContainer.className = 'ml-1 border-l border-sky-800/50 pl-2';
-				appendRecipeTree(childContainer, item.children);
+				appendRecipeTree(childContainer, item.children, displayQuantity);
 				listItem.appendChild(childContainer);
 			} else {
-				listItem.appendChild(createTreeNodeRow(item, true));
+				listItem.appendChild(createTreeNodeRow(displayItem, true));
 			}
 
 			list.appendChild(listItem);

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -136,6 +136,25 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		rawItems: PlannerItem[];
 	};
 
+	type PlannerApiTreeItem = {
+		id?: string;
+		name?: string;
+		icon?: string;
+		quantity?: number;
+		url?: string;
+		children?: PlannerApiTreeItem[];
+	};
+
+	type PlannerApiProduct = {
+		id?: string;
+		name?: string;
+		icon?: string;
+		url?: string;
+		recipeTree?: PlannerApiTreeItem[];
+		ingredients?: PlannerApiTreeItem[];
+		rawItems?: PlannerItem[];
+	};
+
 	type PlanEntry = {
 		id: string;
 		qty: number;
@@ -165,22 +184,59 @@ const imageBaseUrl = SITE.imageBaseUrl;
 	let urlDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let datasetPromise: Promise<PlannerProduct[]> | null = null;
 
+	function normalizeTreeItem(item: PlannerApiTreeItem): PlannerTreeItem | null {
+		if (!item?.id || !item?.name) return null;
+
+		return {
+			id: item.id,
+			name: item.name,
+			icon: item.icon ?? '',
+			quantity: item.quantity ?? 1,
+			url: item.url ?? `/item/${item.id}`,
+			children: (item.children ?? [])
+				.map(normalizeTreeItem)
+				.filter((child): child is PlannerTreeItem => child !== null),
+		};
+	}
+
+	function normalizeProduct(entry: PlannerApiProduct): PlannerProduct | null {
+		if (!entry?.id || !entry?.name || !Array.isArray(entry.rawItems)) return null;
+
+		const treeSource = Array.isArray(entry.recipeTree)
+			? entry.recipeTree
+			: Array.isArray(entry.ingredients)
+				? entry.ingredients
+				: [];
+
+		return {
+			id: entry.id,
+			name: entry.name,
+			icon: entry.icon ?? '',
+			url: entry.url ?? `/item/${entry.id}`,
+			recipeTree: treeSource
+				.map(normalizeTreeItem)
+				.filter((item): item is PlannerTreeItem => item !== null),
+			rawItems: entry.rawItems.filter((item) => item?.id && item?.name),
+		};
+	}
+
 	function loadPlannerDataset(): Promise<PlannerProduct[]> {
 		if (!datasetPromise) {
-			datasetPromise = fetch('/calculator/planner-data.json', { cache: 'force-cache' })
-				.then((response) => response.json())
+			datasetPromise = fetch('/calculator/planner-data.json')
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error(`Planner data request failed (${response.status})`);
+					}
+					return response.json();
+				})
 				.then((results) => {
 					if (!results || !Array.isArray(results.body)) {
 						return [];
 					}
-					return results.body.filter(
-						(entry: PlannerProduct) =>
-							entry &&
-							typeof entry.id === 'string' &&
-							typeof entry.name === 'string' &&
-							Array.isArray(entry.recipeTree) &&
-							Array.isArray(entry.rawItems)
-					);
+
+					return results.body
+						.map((entry: PlannerApiProduct) => normalizeProduct(entry))
+						.filter((entry): entry is PlannerProduct => entry !== null);
 				})
 				.catch((error) => {
 					datasetPromise = null;
@@ -624,6 +680,13 @@ const imageBaseUrl = SITE.imageBaseUrl;
 			productsById.clear();
 			for (const product of products) {
 				productsById.set(product.id, product);
+			}
+
+			if (products.length === 0) {
+				if (planEmpty) {
+					planEmpty.textContent = 'Unable to load product data. Please refresh the page.';
+				}
+				return;
 			}
 
 			plan = parsePlanFromUrl();

--- a/src/pages/calculator/planner.astro
+++ b/src/pages/calculator/planner.astro
@@ -63,42 +63,49 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		</div>
 
 		<section aria-labelledby="plan-heading" class="mb-8">
-			<h2 id="plan-heading" class="text-2xl mb-4">Your plan</h2>
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+				<h2 id="plan-heading" class="mb-0 text-2xl">Your plan</h2>
+				<button
+					id="copy-link-btn"
+					type="button"
+					class="rounded-sm border border-sky-600 bg-sky-900/50 px-3 py-1.5 text-sm text-cyan-300 hover:border-cyan-400 hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
+					disabled
+				>
+					Copy link
+				</button>
+			</div>
 			<div id="plan-rows" class="flex flex-col gap-2"></div>
 			<p id="plan-empty" class="text-sky-200/70 text-sm">
 				No items added yet. Search above to add products (e.g. Stasis Device, Living Glass).
 			</p>
 		</section>
 
-		<section aria-labelledby="totals-heading" class="mb-6">
-			<div class="flex flex-wrap items-center justify-between gap-4 mb-4">
-				<h2 id="totals-heading" class="text-2xl mb-0">Total raw materials</h2>
-				<div class="flex flex-wrap items-center gap-3">
-					<label class="inline-flex cursor-pointer items-center gap-2 text-sm text-sky-200">
-						<input
-							id="breakdown-toggle"
-							type="checkbox"
-							class="peer hidden"
-						/>
-						<span class="select-none rounded-lg border-2 border-sky-600 px-2 py-0.5 transition-colors duration-200 peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
-							Show per-item breakdown
-						</span>
-					</label>
-					<button
-						id="copy-link-btn"
-						type="button"
-						class="rounded-sm border border-sky-600 bg-sky-900/50 px-3 py-1.5 text-sm text-cyan-300 hover:border-cyan-400 hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
-						disabled
-					>
-						Copy link
-					</button>
-				</div>
-			</div>
+		<section aria-labelledby="totals-heading" class="mb-8">
+			<h2 id="totals-heading" class="mb-4 text-2xl">Total raw materials</h2>
 			<div id="totals-list"></div>
 			<p id="totals-empty" class="text-sky-200/70 text-sm hidden">
 				Add products to your plan to see total raw materials.
 			</p>
-			<div id="breakdown-section" class="mt-6 hidden"></div>
+		</section>
+
+		<section aria-labelledby="breakdown-heading" id="breakdown-panel" class="mb-6 hidden">
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+				<h2 id="breakdown-heading" class="mb-0 text-2xl">Per-item breakdown</h2>
+				<label class="inline-flex cursor-pointer items-center gap-2 text-sm text-sky-200">
+					<input
+						id="breakdown-toggle"
+						type="checkbox"
+						class="peer hidden"
+					/>
+					<span class="select-none rounded-lg border-2 border-sky-600 px-2 py-0.5 transition-colors duration-200 peer-checked:border-cyan-400 peer-checked:bg-cyan-500/20 peer-checked:text-cyan-200">
+						Show crafting trees
+					</span>
+				</label>
+			</div>
+			<p id="breakdown-hint" class="text-sky-200/70 text-sm">
+				Expand to see the full crafting tree for each product in your plan, down to raw resources.
+			</p>
+			<div id="breakdown-section" class="hidden"></div>
 		</section>
 	</div>
 </Layout>
@@ -111,12 +118,21 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		quantity: number;
 	};
 
+	type PlannerTreeItem = {
+		id: string;
+		name: string;
+		icon: string;
+		quantity: number;
+		url: string;
+		children: PlannerTreeItem[];
+	};
+
 	type PlannerProduct = {
 		id: string;
 		name: string;
 		icon: string;
 		url: string;
-		ingredients: PlannerItem[];
+		recipeTree: PlannerTreeItem[];
 		rawItems: PlannerItem[];
 	};
 
@@ -135,6 +151,8 @@ const imageBaseUrl = SITE.imageBaseUrl;
 	const totalsList = document.getElementById('totals-list');
 	const totalsEmpty = document.getElementById('totals-empty');
 	const breakdownToggle = document.getElementById('breakdown-toggle') as HTMLInputElement | null;
+	const breakdownPanel = document.getElementById('breakdown-panel');
+	const breakdownHint = document.getElementById('breakdown-hint');
 	const breakdownSection = document.getElementById('breakdown-section');
 	const copyLinkBtn = document.getElementById('copy-link-btn') as HTMLButtonElement | null;
 
@@ -160,7 +178,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 							entry &&
 							typeof entry.id === 'string' &&
 							typeof entry.name === 'string' &&
-							Array.isArray(entry.ingredients) &&
+							Array.isArray(entry.recipeTree) &&
 							Array.isArray(entry.rawItems)
 					);
 				})
@@ -258,19 +276,94 @@ const imageBaseUrl = SITE.imageBaseUrl;
 		return li;
 	}
 
+	function scaleRecipeTree(items: PlannerTreeItem[], multiplier: number): PlannerTreeItem[] {
+		return items.map((item) => ({
+			...item,
+			quantity: item.quantity * multiplier,
+			children: scaleRecipeTree(item.children, multiplier),
+		}));
+	}
+
+	function createTreeQuantityBadge(quantity: number): HTMLSpanElement {
+		const qtySpan = document.createElement('span');
+		qtySpan.className =
+			'inline-flex min-w-7 shrink-0 items-center justify-center rounded-sm bg-sky-800/80 px-1.5 py-0.5 text-xs font-medium tabular-nums text-sky-200';
+		qtySpan.textContent = quantity.toLocaleString();
+		qtySpan.setAttribute('aria-label', `quantity ${quantity}`);
+		return qtySpan;
+	}
+
+	function createTreeNodeRow(item: PlannerTreeItem, isLeaf: boolean): HTMLElement {
+		const row = document.createElement(isLeaf ? 'a' : 'div');
+		row.className = isLeaf
+			? 'flex items-center gap-2 rounded-r py-1.5 pl-1 transition-colors hover:bg-cyan-500/10 border-l-2 border-cyan-500/40'
+			: 'flex items-center gap-2 py-1.5 pl-1';
+
+		if (isLeaf) {
+			(row as HTMLAnchorElement).href = item.url;
+		}
+
+		if (item.icon) {
+			const img = document.createElement('img');
+			img.src = `${imageBaseUrl}${item.icon}`;
+			img.alt = '';
+			img.className = 'h-7 w-7 shrink-0 object-contain';
+			img.loading = 'lazy';
+			row.appendChild(img);
+		}
+
+		const nameSpan = document.createElement('span');
+		nameSpan.className = `min-w-0 flex-1 truncate font-medium ${isLeaf ? 'text-cyan-200' : 'text-sky-100'}`;
+		nameSpan.textContent = item.name;
+		row.appendChild(nameSpan);
+
+		row.appendChild(createTreeQuantityBadge(item.quantity));
+
+		return row;
+	}
+
+	function appendRecipeTree(container: HTMLElement, items: PlannerTreeItem[]) {
+		const list = document.createElement('ul');
+		list.className = 'm-0 list-none p-0';
+
+		for (const item of items) {
+			const listItem = document.createElement('li');
+
+			if (item.children.length > 0) {
+				listItem.appendChild(createTreeNodeRow(item, false));
+
+				const childContainer = document.createElement('div');
+				childContainer.className = 'ml-1 border-l border-sky-800/50 pl-2';
+				appendRecipeTree(childContainer, item.children);
+				listItem.appendChild(childContainer);
+			} else {
+				listItem.appendChild(createTreeNodeRow(item, true));
+			}
+
+			list.appendChild(listItem);
+		}
+
+		container.appendChild(list);
+	}
+
 	function renderTotals() {
-		if (!totalsList || !totalsEmpty || !breakdownSection) return;
+		if (!totalsList || !totalsEmpty || !breakdownSection || !breakdownPanel) return;
 
 		totalsList.textContent = '';
 		breakdownSection.textContent = '';
 
 		if (plan.length === 0) {
 			totalsEmpty.classList.remove('hidden');
+			breakdownPanel.classList.add('hidden');
 			breakdownSection.classList.add('hidden');
+			if (breakdownHint) {
+				breakdownHint.classList.remove('hidden');
+			}
 			return;
 		}
 
 		totalsEmpty.classList.add('hidden');
+		breakdownPanel.classList.remove('hidden');
 		const merged = mergeRawItems(plan);
 
 		const ul = document.createElement('ul');
@@ -282,31 +375,46 @@ const imageBaseUrl = SITE.imageBaseUrl;
 
 		if (breakdownToggle?.checked) {
 			breakdownSection.classList.remove('hidden');
+			if (breakdownHint) {
+				breakdownHint.classList.add('hidden');
+			}
+
 			for (const entry of plan) {
 				const product = productsById.get(entry.id);
 				if (!product) continue;
 
+				const productBlock = document.createElement('article');
+				productBlock.className =
+					'mt-4 rounded-sm border border-sky-800 bg-sky-900/20 p-3 first:mt-0';
+
 				const heading = document.createElement('h3');
-				heading.className = 'text-lg mt-4 mb-2 text-cyan-200';
-				heading.textContent = `${product.name} × ${entry.qty.toLocaleString()}`;
-				breakdownSection.appendChild(heading);
+				heading.className = 'mb-3 flex items-center gap-2 text-lg text-cyan-200';
 
-				const itemUl = document.createElement('ul');
-				itemUl.className = 'm-0 flex list-none flex-col p-0 pl-2 border-l border-sky-800';
-				const scaled = product.ingredients
-					.map((ingredient) => ({
-						...ingredient,
-						quantity: ingredient.quantity * entry.qty,
-					}))
-					.sort((a, b) => b.quantity - a.quantity);
-
-				for (const ingredient of scaled) {
-					itemUl.appendChild(createItemRow(ingredient));
+				if (product.icon) {
+					const img = document.createElement('img');
+					img.src = `${imageBaseUrl}${product.icon}`;
+					img.alt = '';
+					img.className = 'h-7 w-7 shrink-0 object-contain';
+					img.loading = 'lazy';
+					heading.appendChild(img);
 				}
-				breakdownSection.appendChild(itemUl);
+
+				const headingText = document.createElement('span');
+				headingText.textContent = `${product.name} × ${entry.qty.toLocaleString()}`;
+				heading.appendChild(headingText);
+				productBlock.appendChild(heading);
+
+				const treeContainer = document.createElement('div');
+				treeContainer.className = 'ml-1';
+				appendRecipeTree(treeContainer, scaleRecipeTree(product.recipeTree, entry.qty));
+				productBlock.appendChild(treeContainer);
+				breakdownSection.appendChild(productBlock);
 			}
 		} else {
 			breakdownSection.classList.add('hidden');
+			if (breakdownHint) {
+				breakdownHint.classList.remove('hidden');
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the crafting planner per-item breakdown, search regression, layout, quantity math, and leaf styling.

**Quantity fix:** Plan quantity was applied twice — once by pre-scaling the entire recipe tree and again while multiplying through parent quantities. For 10 Stasis Devices this inflated Star Bulbs from 2,000 to 2,000,000. Plan qty is now only passed as the top-level parent multiplier.

**Leaf border fix:** Raw-material rows inside bordered child containers no longer add a second left border.

**Search regression fix:** The client required a `recipeTree` field on every product, but deployed `planner-data.json` may still use the older `rawItems`-only format until a full rebuild completes.

**Breakdown:** Shows the full multi-level crafting tree for each planned product, recursively down to raw resources.

**Layout:** Copy link in Your plan header; Show crafting trees toggle in Per-item breakdown section below totals.

## Test plan

- [x] 10× Stasis Device → Star Bulb shows 2,000 (not 2,000,000)
- [x] Leaf items no longer show double left border
- [x] Search works with old and new planner-data formats
- [x] Nested crafting trees render correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8078f48-7de1-4981-8309-c220424b33ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8078f48-7de1-4981-8309-c220424b33ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

