### PR TITLE
Fix legacy item URL redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,16 @@
 import { defineConfig } from 'astro/config';
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync } from 'node:fs';
 
 import { SITE } from './src/config.ts';
+
+const legacyRedirects = JSON.parse(
+  readFileSync(new URL('./redirects.generated.json', import.meta.url), 'utf8')
+);
+const LEGACY_REDIRECT_PATHS = new Set(
+  legacyRedirects.map(({ source }) => source.replace(/\/$/, ''))
+);
 
 const SITEMAP_EXCLUDED_PATHS = new Set([
   '/feedback',
@@ -19,6 +27,10 @@ const shouldIncludeInSitemap = (page) => {
   const pathname = pageUrl.pathname.replace(/\/$/, '') || '/';
 
   if (SITEMAP_EXCLUDED_PATHS.has(pathname)) {
+    return false;
+  }
+
+  if (LEGACY_REDIRECT_PATHS.has(pathname)) {
     return false;
   }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['scripts/**/*.js'],
+    files: ['scripts/**/*.{js,mjs}'],
     languageOptions: {
       globals: {
         console: 'readonly',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"astro": "astro",
 		"lint": "eslint . --ext .js,.jsx,.ts,.tsx,.astro --max-warnings 0",
 		"lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx,.astro --fix",
+		"test:legacy-redirects": "node scripts/check-legacy-redirects.mjs",
 		"type-check": "tsc --noEmit",
 		"check": "pnpm run type-check",
 		"check:all": "pnpm run type-check && pnpm run lint"

--- a/scripts/check-legacy-redirects.mjs
+++ b/scripts/check-legacy-redirects.mjs
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const vercelConfig = JSON.parse(await readFile('vercel.json', 'utf8'));
+const vercelConfigText = JSON.stringify(vercelConfig);
+if (vercelConfigText.includes('/api/legacy-redirect')) {
+  throw new Error('vercel.json still references the missing legacy redirect API route.');
+}
+
+const redirectMap = JSON.parse(await readFile('redirects.generated.json', 'utf8'));
+const samples = [
+  '/raw/raw1',
+  '/products/prod1',
+  '/buildings/build10',
+  '/technology/tech99',
+  '/cooking/cook1',
+];
+
+for (const source of samples) {
+  const redirect = redirectMap.find((entry) => entry.source === source);
+  if (!redirect) {
+    throw new Error(`Missing legacy redirect mapping for ${source}.`);
+  }
+
+  const outputPath = join('dist', ...source.slice(1).split('/'), 'index.html');
+  if (!existsSync(outputPath)) {
+    throw new Error(`Missing built redirect page at ${outputPath}. Run pnpm run build first.`);
+  }
+
+  const html = await readFile(outputPath, 'utf8');
+  if (!html.includes(redirect.destination)) {
+    throw new Error(`${outputPath} does not point to ${redirect.destination}.`);
+  }
+}
+
+console.log(`Verified ${samples.length} legacy redirect pages.`);

--- a/scripts/check-legacy-redirects.mjs
+++ b/scripts/check-legacy-redirects.mjs
@@ -34,4 +34,4 @@ for (const source of samples) {
   }
 }
 
-console.log(`Verified ${samples.length} legacy redirect pages.`);
+console.warn(`Verified ${samples.length} legacy redirect pages.`);

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -23,13 +23,12 @@ type LegacyRedirect = {
 	permanent: boolean;
 };
 
-const getPathParts = (pathname: string): { category: string; id: string } | undefined => {
-	const [category, id] = pathname.replace(/^\/+|\/+$/g, '').split('/');
-	if (!category || !id) return undefined;
-	return { category, id };
-};
-
 export async function getStaticPaths() {
+	const getPathParts = (pathname: string): { category: string; id: string } | undefined => {
+		const [category, id] = pathname.replace(/^\/+|\/+$/g, '').split('/');
+		if (!category || !id) return undefined;
+		return { category, id };
+	};
 	const currentPaths = CATEGORY_SLUGS.flatMap((slug) => {
 		const config = categories[slug];
 

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -7,9 +7,30 @@ import { buildItemMeta } from '@utils/seo.js';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
 import { SITE } from '@config';
+import legacyRedirects from '../../../redirects.generated.json';
+
+type StaticPath = {
+	params: {
+		category: string;
+		id: string;
+	};
+	props?: Props;
+};
+
+type LegacyRedirect = {
+	source: string;
+	destination: string;
+	permanent: boolean;
+};
+
+const getPathParts = (pathname: string): { category: string; id: string } | undefined => {
+	const [category, id] = pathname.replace(/^\/+|\/+$/g, '').split('/');
+	if (!category || !id) return undefined;
+	return { category, id };
+};
 
 export async function getStaticPaths() {
-	return CATEGORY_SLUGS.flatMap((slug) => {
+	const currentPaths = CATEGORY_SLUGS.flatMap((slug) => {
 		const config = categories[slug];
 
 		if (config.idStrategy === 'getById') {
@@ -27,15 +48,41 @@ export async function getStaticPaths() {
 			params: { category: slug, id: item.Id.toString() },
 			props: { item },
 		}));
-	});
+	}) satisfies StaticPath[];
+	const currentPathKeys = new Set(
+		currentPaths.map(({ params }) => `/${params.category}/${params.id}`.toLowerCase())
+	);
+	const legacyPaths = (legacyRedirects as LegacyRedirect[]).flatMap((redirect) => {
+		const source = getPathParts(redirect.source);
+		if (!source) return [];
+
+		const sourceKey = `/${source.category}/${source.id}`.toLowerCase();
+		if (currentPathKeys.has(sourceKey)) return [];
+
+		return [{
+			params: source,
+			props: { legacyDestination: redirect.destination },
+		}];
+	}) satisfies StaticPath[];
+
+	return [...currentPaths, ...legacyPaths];
 }
 
 interface Props {
-	item: Item;
+	item?: Item;
+	legacyDestination?: string;
+}
+
+const { legacyDestination } = Astro.props as Props;
+if (legacyDestination) {
+	return Astro.redirect(legacyDestination, 301);
 }
 
 const slug = Astro.params.category as CategorySlug;
 const config = categories[slug];
+if (!config) {
+	return Astro.redirect('/404');
+}
 
 let item: Item | undefined;
 if (config.idStrategy === 'getById') {
@@ -48,6 +95,10 @@ if (config.idStrategy === 'getById') {
 	if (!item && config.redirectGuard) {
 		return Astro.redirect('/404');
 	}
+}
+
+if (!item) {
+	return Astro.redirect('/404');
 }
 
 const { title, description } = buildItemMeta(item, config.idLabel);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,7 +40,7 @@ const cards = [
 	{
 		name: 'New Items',
 		description:
-			`See everything added or updated in the latest No Man\'s Sky patch: ${SITE.version_name} (${SITE.version})`,
+			`See everything added or updated in the latest No Man's Sky patch: ${SITE.version_name} (${SITE.version})`,
 		button: 'View New Items',
 		image: `${SITE.imageBaseUrl}SWARM_ARMOUR.png`,
 		link: '/new',

--- a/vercel.json
+++ b/vercel.json
@@ -34,18 +34,5 @@
     { "source": "/upgrades/1/", "destination": "/upgrades", "permanent": true },
     { "source": "/sitemap", "destination": "/sitemap-0.xml", "permanent": true },
     { "source": "/sitemap.xml", "destination": "/sitemap-index.xml", "permanent": true }
-  ],
-  "rewrites": [
-    { "source": "/buildings/:id(build\\d+)", "destination": "/api/legacy-redirect?segment=buildings&id=:id" },
-    { "source": "/cooking/:id(cook\\d+)", "destination": "/api/legacy-redirect?segment=cooking&id=:id" },
-    { "source": "/curiosities/:id(cur\\d+)", "destination": "/api/legacy-redirect?segment=curiosities&id=:id" },
-    { "source": "/fish/:id(cur\\d+)", "destination": "/api/legacy-redirect?segment=fish&id=:id" },
-    { "source": "/other/:id(other\\d+)", "destination": "/api/legacy-redirect?segment=other&id=:id" },
-    { "source": "/other/:id(trade\\d+)", "destination": "/api/legacy-redirect?segment=other&id=:id" },
-    { "source": "/products/:id(prod\\d+)", "destination": "/api/legacy-redirect?segment=products&id=:id" },
-    { "source": "/raw/:id(raw\\d+)", "destination": "/api/legacy-redirect?segment=raw&id=:id" },
-    { "source": "/technology/:id(conTech\\d+)", "destination": "/api/legacy-redirect?segment=technology&id=:id" },
-    { "source": "/technology/:id(tech\\d+)", "destination": "/api/legacy-redirect?segment=technology&id=:id" },
-    { "source": "/technology/:id(tMod\\d+)", "destination": "/api/legacy-redirect?segment=technology&id=:id" }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Generate static redirect pages for legacy numeric item URLs from `redirects.generated.json`.
- Remove stale Vercel rewrites that pointed those URLs at a missing `/api/legacy-redirect` route.
- Exclude legacy redirect aliases from generated sitemaps.
- Add a post-build legacy redirect verification script.

### Validation
- `pnpm run type-check && pnpm run lint && pnpm run build && pnpm run test:legacy-redirects`
- Node sitemap assertion confirming current targets are present and legacy aliases are absent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86fecaed-9e98-4989-af32-90e126075e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86fecaed-9e98-4989-af32-90e126075e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

