### PR TITLE
Fix legacy redirects and harden analytics snippet

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -136,8 +136,8 @@ inject();
 		<script async src="https://www.googletagmanager.com/gtag/js?id=G-9GEFK3YPV3"></script>
 		<script is:inline>
 			window.dataLayer = window.dataLayer || [];
-			function gtag(...args) {
-				dataLayer.push(args);
+			function gtag() {
+				dataLayer.push(arguments);
 			}
 			gtag('js', new Date());
 			gtag('config', 'G-9GEFK3YPV3');

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -137,6 +137,7 @@ inject();
 		<script is:inline>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() {
+				// eslint-disable-next-line prefer-rest-params -- Google tag's stock snippet queues the Arguments object.
 				dataLayer.push(arguments);
 			}
 			gtag('js', new Date());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Generate static redirect pages for legacy numeric item URLs from `redirects.generated.json`.
- Remove stale Vercel rewrites that pointed those URLs at a missing `/api/legacy-redirect` route.
- Exclude legacy redirect aliases from generated sitemaps.
- Add a post-build legacy redirect verification script.
- Restore the Google Analytics `gtag` queue to Google's stock `dataLayer.push(arguments)` snippet.

### Validation
- `pnpm run type-check && pnpm run lint && pnpm run build && pnpm run test:legacy-redirects`
- Node sitemap assertion confirming current targets are present and legacy aliases are absent.
- `pnpm run lint && pnpm run build && <analytics coverage audit>` verified representative generated pages include GA + AdSense, and all non-redirect HTML pages have both scripts.
- Chrome DevTools Protocol probe against live production loaded `gtag.js` but captured `0` GA collect hits with the currently deployed `dataLayer.push(args)` snippet.
- The same Chrome probe against local preview with the stock snippet captured a GA4 `page_view` request to `https://www.google-analytics.com/g/collect`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86fecaed-9e98-4989-af32-90e126075e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86fecaed-9e98-4989-af32-90e126075e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

