### PR TITLE
Fix search bar text color on dark backgrounds

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -184,6 +184,10 @@
     @apply inline-flex items-center rounded-md border border-transparent bg-blue-500 px-3 py-2 text-sm font-medium leading-4 text-black shadow-xs hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
 }
 
+.tabulator-search input {
+    @apply text-white placeholder-gray-400;
+}
+
 #results li a {
     @apply select-none block hover:bg-blue-500 hover:text-black  focus:bg-blue-500 focus:text-black
 }

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -32,7 +32,7 @@ const imageBaseUrl = SITE.imageBaseUrl;
 				</svg>
 
 				<input id="search-input" type="text" class="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-white placeholder-gray-400 focus:ring-0 sm:text-sm" placeholder="Search..." role="combobox" aria-expanded="false" aria-controls="options" aria-label="Search items and blog posts" />
-				<p class="text-sm px-4">Select Categories</p>
+				<p class="text-sm px-4 text-white">Select Categories</p>
 				<div class="flex flex-wrap gap-2 px-4 pb-4 pt-2">
 					{
 						filters.map((filter) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes unreadable search bar text where typed input appeared black on a black background.

## Changes

- Add a shared CSS rule so `.tabulator-search` inputs use white text and a gray placeholder. This covers the search fields on refining, crafting, cooking, and related table/card pages.
- Set the global search modal "Select Categories" label to white for consistency on the dark modal background.

## Testing

- Verified on `/refining`: typed search text is white and visible on the dark input background.
- Verified on the homepage global search modal (`/` shortcut): typed search text is white and visible.
- `pnpm run lint` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45c65a91-c172-484b-9d38-8f3722c57bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45c65a91-c172-484b-9d38-8f3722c57bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

