### PR TITLE
Fix SchemaScore structured data gaps (63/100 → enriched)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,4 @@ export const SITE = {
         width: 444,
         height: 441,
     },
-    social: [
-        'https://github.com/bradhave94/nms',
-        'https://steamcommunity.com/sharedfiles/filedetails/?id=2179757979',
-    ],
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,4 +9,13 @@ export const SITE = {
     version_link: "https://www.nomanssky.com/swarm-update/",
     adsense_id: 'ca-pub-8524094599848175',
     imageBaseUrl: 'https://nomansskyrecipes.com/images/items/',
+    logo: {
+        url: '/images/icon.png',
+        width: 444,
+        height: 441,
+    },
+    social: [
+        'https://github.com/bradhave94/nms',
+        'https://steamcommunity.com/sharedfiles/filedetails/?id=2179757979',
+    ],
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,6 @@ export interface Props {
 	articleModifiedTime?: string;
 	slug?: string;
 	structuredData?: JsonLdObject | JsonLdObject[];
-	suppressWebPage?: boolean;
 	robots?: string;
 	canonical?: string;
 	prevUrl?: string;
@@ -39,7 +38,6 @@ const {
 	description = SITE.desc,
 	slug,
 	structuredData,
-	suppressWebPage = false,
 	ogImage,
 	ogType = 'website',
 	articlePublishedTime,
@@ -61,16 +59,15 @@ const extraStructuredData = structuredData
 	? (Array.isArray(structuredData) ? structuredData : [structuredData])
 	: [];
 const dateModified = (articleModifiedTime ?? SITE.version_date).slice(0, 10);
-const webPageSchema =
-	!suppressWebPage && !hasPageEntity(extraStructuredData)
-		? buildWebPageSchema({
+const webPageSchema = !hasPageEntity(extraStructuredData)
+	? buildWebPageSchema({
 				siteOrigin,
 				canonicalUrl: canonicalURL.toString(),
 				title,
 				description,
-				dateModified,
-			})
-		: undefined;
+			dateModified,
+		})
+	: undefined;
 const mergedStructuredData: JsonLdObject[] = [
 	organizationSchema,
 	webSiteSchema,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,6 +26,7 @@ export interface Props {
 	articleModifiedTime?: string;
 	slug?: string;
 	structuredData?: JsonLdObject | JsonLdObject[];
+	suppressWebPage?: boolean;
 	robots?: string;
 	canonical?: string;
 	prevUrl?: string;
@@ -38,6 +39,7 @@ const {
 	description = SITE.desc,
 	slug,
 	structuredData,
+	suppressWebPage = false,
 	ogImage,
 	ogType = 'website',
 	articlePublishedTime,
@@ -58,19 +60,19 @@ const webSiteSchema = buildWebSiteSchema(siteOrigin);
 const extraStructuredData = structuredData
 	? (Array.isArray(structuredData) ? structuredData : [structuredData])
 	: [];
-const isHomePage = Astro.url.pathname === '/';
 const dateModified = (articleModifiedTime ?? SITE.version_date).slice(0, 10);
-const webPageSchema = hasPageEntity(extraStructuredData)
-	? undefined
-	: buildWebPageSchema({
-			siteOrigin,
-			canonicalUrl: canonicalURL.toString(),
-			title,
-			description,
-			dateModified,
-		});
+const webPageSchema =
+	!suppressWebPage && !hasPageEntity(extraStructuredData)
+		? buildWebPageSchema({
+				siteOrigin,
+				canonicalUrl: canonicalURL.toString(),
+				title,
+				description,
+				dateModified,
+			})
+		: undefined;
 const mergedStructuredData: JsonLdObject[] = [
-	...(isHomePage ? [organizationSchema] : []),
+	organizationSchema,
 	webSiteSchema,
 	...(webPageSchema ? [webPageSchema] : []),
 	...extraStructuredData,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,13 @@
 import '../assets/css/main.css';
 import { inject } from '@vercel/analytics';
 import type { JsonLdObject } from '@utils/structuredData.js';
+import {
+	buildOrganizationSchema,
+	buildWebPageSchema,
+	buildWebSiteSchema,
+	hasPageEntity,
+	serializeJsonLdGraph,
+} from '@utils/structuredData.js';
 
 import Sidebar from '@layouts/Sidebar.astro';
 import Search from '@components/Search.astro';
@@ -46,38 +53,29 @@ const canonicalURL = canonical
 const siteOrigin = SITE.website.replace(/\/$/, '');
 const defaultOgImage = `${siteOrigin}/images/icon.png`;
 const imageUrl = ogImage ?? defaultOgImage;
-const organizationSchema: JsonLdObject = {
-	'@context': 'https://schema.org',
-	'@type': 'Organization',
-	'@id': `${siteOrigin}#organization`,
-	name: SITE.title,
-	url: `${siteOrigin}/`,
-	logo: `${siteOrigin}/images/icon.png`,
-};
-const webSiteSchema: JsonLdObject = {
-	'@context': 'https://schema.org',
-	'@type': 'WebSite',
-	'@id': `${siteOrigin}#website`,
-	url: `${siteOrigin}/`,
-	name: SITE.title,
-	description: SITE.desc,
-	publisher: { '@id': `${siteOrigin}#organization` },
-	potentialAction: {
-		'@type': 'SearchAction',
-		target: `${siteOrigin}/items?q={search_term_string}`,
-		'query-input': 'required name=search_term_string',
-	},
-};
+const organizationSchema = buildOrganizationSchema(siteOrigin);
+const webSiteSchema = buildWebSiteSchema(siteOrigin);
 const extraStructuredData = structuredData
 	? (Array.isArray(structuredData) ? structuredData : [structuredData])
 	: [];
 const isHomePage = Astro.url.pathname === '/';
+const dateModified = (articleModifiedTime ?? SITE.version_date).slice(0, 10);
+const webPageSchema = hasPageEntity(extraStructuredData)
+	? undefined
+	: buildWebPageSchema({
+			siteOrigin,
+			canonicalUrl: canonicalURL.toString(),
+			title,
+			description,
+			dateModified,
+		});
 const mergedStructuredData: JsonLdObject[] = [
 	...(isHomePage ? [organizationSchema] : []),
 	webSiteSchema,
+	...(webPageSchema ? [webPageSchema] : []),
 	...extraStructuredData,
 ];
-const mergedStructuredDataJson = JSON.stringify(mergedStructuredData).replace(/</g, '\\u003c');
+const mergedStructuredDataJson = serializeJsonLdGraph(mergedStructuredData);
 
 inject();
 ---

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -22,19 +22,18 @@ import {
   type UsedInItem,
 } from '@utils/recipeTree';
 import { formatSignedPercent, formatFoodEffectStats } from '@utils/itemFormatters';
-import { buildItemPageSchema } from '@utils/itemPageSchema';
+import type { ItemPageSchemaResult } from '@utils/itemPageSchema';
 import refinery from '@datav2/Refinery.json';
 import { SITE } from '@config';
 
 // Define the props interface
 interface Props {
   item: Item;
+  schemaResult: ItemPageSchemaResult;
 }
 
-const { item } = Astro.props;
+const { item, schemaResult } = Astro.props;
 const itemUpdateMeta = getItemUpdateMeta(item.Id);
-const siteOrigin = (Astro.site ? new URL('/', Astro.site) : new URL('/', Astro.url)).toString().replace(/\/$/, '');
-const canonicalUrl = new URL(Astro.url.pathname, siteOrigin).toString();
 const normalizedSlug = (item.Slug ?? '').replace(/^\/+/, '').replace(/^cooking\//, 'food/');
 const categorySlug = normalizedSlug.split('/')[0] || 'items';
 const categoryNameMap: Record<string, string> = {
@@ -67,25 +66,7 @@ const categoryFirstPagePathMap: Record<string, string> = {
   corvette: '/corvette',
 };
 const categoryName = categoryNameMap[categorySlug] ?? 'Items';
-const categorySingularMap: Record<string, string> = {
-  raw: 'raw material',
-  products: 'product',
-  food: 'food item',
-  curiosities: 'curiosity',
-  fish: 'fish',
-  technology: 'technology item',
-  other: 'item',
-  buildings: 'building part',
-  upgrades: 'upgrade',
-  exocraft: 'exocraft item',
-  starships: 'starship item',
-  corvette: 'corvette item',
-  refinery: 'refined item',
-};
-const categorySingular = categorySingularMap[categorySlug] ?? 'item';
 const categoryPath = categoryFirstPagePathMap[categorySlug] ?? '/items';
-const categoryUrl = `${siteOrigin}${categoryPath}`;
-const itemImageUrl = `${siteOrigin}/images/items/${item.Icon}`;
 
 type UpgradeStatLevel = {
   StatType?: string;
@@ -301,25 +282,10 @@ const growTimeHeader = getGrowTimeHeader();
 const {
   faqQuestions,
   answerSummary,
-  itemPageStructuredDataJson,
   recipeIngredients,
   recipeToolName,
   recipeOutputQuantity,
-} = buildItemPageSchema({
-  item,
-  categoryName,
-  categorySingular,
-  categoryUrl,
-  siteOrigin,
-  canonicalUrl,
-  itemImageUrl,
-  isFoodItem,
-  outputRecipes,
-  rawItems,
-  dataLength: data.length,
-  outputRefinedLength: outputRefined.length,
-  outputCookedLength: outputCooked.length,
-});
+} = schemaResult;
 
 const pinObjectiveLabel =
   exocraftItem.PinObjective === 'UI_FIND_BUY_OBJ'
@@ -532,8 +498,6 @@ const imageBaseUrl = SITE.imageBaseUrl;
 
   <ItemFaq faqQuestions={faqQuestions} />
 </div>
-
-<script type="application/ld+json" set:html={itemPageStructuredDataJson}></script>
 
 <!-- Quantity input script -->
 {showQuantityInput && (

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -4,6 +4,10 @@ import Page from '@layouts/Page.astro';
 import { getById, sort } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import { buildItemMeta } from '@utils/seo.js';
+import { getSiteOrigin } from '@utils/structuredData.js';
+import { prepareItemPageSchemaInput } from '@utils/itemPageContext';
+import { buildItemPageSchema } from '@utils/itemPageSchema';
+import { getItemDateModified } from '@utils/updateChanges';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
 import { SITE } from '@config';
@@ -102,8 +106,13 @@ if (!item) {
 
 const { title, description } = buildItemMeta(item, config.idLabel);
 const ogImage = `${SITE.imageBaseUrl}${item.Icon}`;
+const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
+const schemaResult = buildItemPageSchema({
+	...prepareItemPageSchemaInput(item, siteOrigin, Astro.url.pathname),
+	dateModified: getItemDateModified(item.Id),
+});
 ---
 
-<Layout {title} {description} slug={config.slug} {ogImage} suppressWebPage>
-	<Page item={item} />
+<Layout {title} {description} slug={config.slug} {ogImage} structuredData={schemaResult.structuredData}>
+	<Page item={item} schemaResult={schemaResult} />
 </Layout>

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -104,6 +104,6 @@ const { title, description } = buildItemMeta(item, config.idLabel);
 const ogImage = `${SITE.imageBaseUrl}${item.Icon}`;
 ---
 
-<Layout {title} {description} slug={config.slug} {ogImage}>
+<Layout {title} {description} slug={config.slug} {ogImage} suppressWebPage>
 	<Page item={item} />
 </Layout>

--- a/src/pages/creatures/[id].astro
+++ b/src/pages/creatures/[id].astro
@@ -2,9 +2,9 @@
 import Layout from '@layouts/Layout.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import type { BreadcrumbItem } from '@utils/seo.js';
-import { getSiteOrigin } from '@utils/structuredData.js';
-import creaturesData from '@datav2/Creatures.json';
+import { getSiteOrigin, buildPageSignals } from '@utils/structuredData.js';
 import { SITE } from '@config';
+import creaturesData from '@datav2/Creatures.json';
 
 type CreatureSpecies = (typeof creaturesData.Species)[number];
 type CreatureMove = (typeof creaturesData.BattleMoves)[number];
@@ -298,6 +298,7 @@ const collectionSchema = {
 	url: canonicalUrl,
 	name: pageTitle,
 	description,
+	...buildPageSignals({ siteOrigin }),
 	breadcrumb: {
 		'@type': 'BreadcrumbList',
 		itemListElement: [

--- a/src/pages/items/index.astro
+++ b/src/pages/items/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import { getSiteOrigin } from '@utils/structuredData.js';
+import { getSiteOrigin, buildPageSignals } from '@utils/structuredData.js';
 import { SITE } from '@config';
 
 const IMAGE_BASE = SITE.imageBaseUrl;
@@ -45,8 +45,8 @@ const collectionSchema = {
 	url: canonicalUrl,
 	name: 'Items',
 	description: 'Browse items by group, type, or search. Filter No Man\'s Sky items dynamically.',
-	isPartOf: { '@id': `${siteOrigin}#website` },
 	breadcrumb: { '@id': `${canonicalUrl}#breadcrumb` },
+	...buildPageSignals({ siteOrigin }),
 	mainEntity: { '@id': `${siteOrigin}/items.json#dataset` },
 };
 const structuredData = [breadcrumbSchema, collectionSchema, datasetSchema];

--- a/src/utils/guideStructuredData.ts
+++ b/src/utils/guideStructuredData.ts
@@ -1,4 +1,5 @@
 import type { JsonLdObject } from '@utils/structuredData.js';
+import { buildPageSignals } from '@utils/structuredData.js';
 
 type BreadcrumbItemInput = {
 	name: string;
@@ -35,6 +36,7 @@ export const buildGuideStructuredData = ({
 	keywords,
 	faqs = [],
 }: BuildGuideStructuredDataOptions): JsonLdObject[] => {
+	const siteOrigin = new URL(canonicalUrl).origin;
 	const breadcrumbSchema: JsonLdObject = {
 		'@context': 'https://schema.org',
 		'@type': 'BreadcrumbList',
@@ -51,21 +53,18 @@ export const buildGuideStructuredData = ({
 		'@context': 'https://schema.org',
 		'@type': 'BlogPosting',
 		'@id': `${canonicalUrl}#article`,
-		mainEntityOfPage: canonicalUrl,
+		mainEntityOfPage: { '@id': `${canonicalUrl}#article` },
 		headline: title,
 		description,
 		datePublished: publishedTime,
-		dateModified: modifiedTime,
 		author: {
 			'@type': 'Person',
 			name: authorName,
 		},
-		publisher: {
-			'@type': 'Organization',
-			name: "No Man's Sky Recipes",
-		},
+		publisher: { '@id': `${siteOrigin}#organization` },
 		breadcrumb: { '@id': `${canonicalUrl}#breadcrumb` },
-		...(image ? { image } : {}),
+		...buildPageSignals({ siteOrigin, dateModified: modifiedTime.slice(0, 10) }),
+		...(image ? { image: { '@type': 'ImageObject', url: image } } : {}),
 		...(keywords && keywords.length > 0 ? { keywords: keywords.join(', ') } : {}),
 	};
 

--- a/src/utils/itemPageContext.ts
+++ b/src/utils/itemPageContext.ts
@@ -1,0 +1,100 @@
+import { findOutput } from '@utils/lookup.js';
+import type { Item } from '@utils/lookup.js';
+import { createArray } from '@utils/recipeTree';
+import type { RecipeOutput } from '@utils/recipeTree';
+import type { ItemPageSchemaInput } from '@utils/itemPageSchema';
+
+export type ItemPageSchemaContext = Omit<ItemPageSchemaInput, 'dateModified'>;
+
+const categoryNameMap: Record<string, string> = {
+	raw: 'Raw Materials',
+	products: 'Products',
+	food: 'Food',
+	curiosities: 'Curiosities',
+	fish: 'Fish',
+	technology: 'Technology',
+	other: 'Other',
+	refinery: 'Refinery',
+	buildings: 'Buildings',
+	upgrades: 'Upgrades',
+	exocraft: 'Exocraft',
+	starships: 'Starships',
+	corvette: 'Corvette',
+};
+
+const categoryFirstPagePathMap: Record<string, string> = {
+	raw: '/raw',
+	products: '/products',
+	food: '/food',
+	curiosities: '/curiosities',
+	fish: '/fish',
+	technology: '/technology',
+	other: '/other',
+	buildings: '/buildings',
+	upgrades: '/upgrades',
+	exocraft: '/exocraft',
+	starships: '/starships',
+	corvette: '/corvette',
+};
+
+const categorySingularMap: Record<string, string> = {
+	raw: 'raw material',
+	products: 'product',
+	food: 'food item',
+	curiosities: 'curiosity',
+	fish: 'fish',
+	technology: 'technology item',
+	other: 'item',
+	buildings: 'building part',
+	upgrades: 'upgrade',
+	exocraft: 'exocraft item',
+	starships: 'starship item',
+	corvette: 'corvette item',
+	refinery: 'refined item',
+};
+
+export const prepareItemPageSchemaInput = (
+	item: Item,
+	siteOrigin: string,
+	pathname: string,
+): ItemPageSchemaContext => {
+	const canonicalUrl = new URL(pathname, siteOrigin).toString();
+	const normalizedSlug = (item.Slug ?? '').replace(/^\/+/, '').replace(/^cooking\//, 'food/');
+	const categorySlug = normalizedSlug.split('/')[0] || 'items';
+	const categoryName = categoryNameMap[categorySlug] ?? 'Items';
+	const categorySingular = categorySingularMap[categorySlug] ?? 'item';
+	const categoryPath = categoryFirstPagePathMap[categorySlug] ?? '/items';
+	const categoryUrl = `${siteOrigin}${categoryPath}`;
+	const itemImageUrl = `${siteOrigin}/images/items/${item.Icon}`;
+	const isFoodItem = Boolean(item.Slug?.startsWith('food/') || item.Slug?.startsWith('cooking/'));
+
+	const { rawItems } = createArray(item);
+	const dataLength = item.RequiredItems?.length ? 1 : 0;
+	const outputRecipes = findOutput(item.Id) as unknown as RecipeOutput[];
+
+	let outputRefinedLength = 0;
+	let outputCookedLength = 0;
+	for (const entry of outputRecipes) {
+		if (entry.Slug?.startsWith('nutrient-processor/')) {
+			outputCookedLength += 1;
+		} else {
+			outputRefinedLength += 1;
+		}
+	}
+
+	return {
+		item,
+		categoryName,
+		categorySingular,
+		categoryUrl,
+		siteOrigin,
+		canonicalUrl,
+		itemImageUrl,
+		isFoodItem,
+		outputRecipes,
+		rawItems,
+		dataLength,
+		outputRefinedLength,
+		outputCookedLength,
+	};
+};

--- a/src/utils/itemPageSchema.ts
+++ b/src/utils/itemPageSchema.ts
@@ -1,8 +1,7 @@
 import { getById } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import type { JsonLdObject } from '@utils/structuredData';
-import { buildPageSignals, serializeJsonLdGraph } from '@utils/structuredData';
-import { SITE } from '@config';
+import { buildPageSignals } from '@utils/structuredData';
 import type { IOItem, RawItem, RecipeOutput } from '@utils/recipeTree';
 
 export type HowToIngredient = {
@@ -35,12 +34,13 @@ export type ItemPageSchemaInput = {
   dataLength: number;
   outputRefinedLength: number;
   outputCookedLength: number;
+  dateModified: string;
 };
 
 export type ItemPageSchemaResult = {
   faqQuestions: FaqQuestion[];
   answerSummary: string;
-  itemPageStructuredDataJson: string;
+  structuredData: JsonLdObject[];
   recipeIngredients: HowToIngredient[];
   recipeToolName: string;
   recipeOutputQuantity: number;
@@ -68,6 +68,7 @@ export const buildItemPageSchema = ({
   dataLength,
   outputRefinedLength,
   outputCookedLength,
+  dateModified,
 }: ItemPageSchemaInput): ItemPageSchemaResult => {
   const howToMethods: HowToMethod[] = [];
   const craftingHowToIngredients = toHowToIngredients(item.RequiredItems ?? []);
@@ -185,7 +186,7 @@ export const buildItemPageSchema = ({
     name: `${item.Name} | No Man's Sky Recipes`,
     description: item.Description,
     breadcrumb: { '@id': `${canonicalUrl}#breadcrumb` },
-    ...buildPageSignals({ siteOrigin, dateModified: SITE.version_date }),
+    ...buildPageSignals({ siteOrigin, dateModified }),
     primaryImageOfPage: {
       '@type': 'ImageObject',
       url: itemImageUrl,
@@ -326,12 +327,10 @@ export const buildItemPageSchema = ({
   if (recipeSchema) {
     itemPageStructuredData.push(recipeSchema);
   }
-  const itemPageStructuredDataJson = serializeJsonLdGraph(itemPageStructuredData);
-
   return {
     faqQuestions,
     answerSummary,
-    itemPageStructuredDataJson,
+    structuredData: itemPageStructuredData,
     recipeIngredients,
     recipeToolName,
     recipeOutputQuantity,

--- a/src/utils/itemPageSchema.ts
+++ b/src/utils/itemPageSchema.ts
@@ -1,6 +1,8 @@
 import { getById } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
 import type { JsonLdObject } from '@utils/structuredData';
+import { buildPageSignals, serializeJsonLdGraph } from '@utils/structuredData';
+import { SITE } from '@config';
 import type { IOItem, RawItem, RecipeOutput } from '@utils/recipeTree';
 
 export type HowToIngredient = {
@@ -182,8 +184,8 @@ export const buildItemPageSchema = ({
     url: canonicalUrl,
     name: `${item.Name} | No Man's Sky Recipes`,
     description: item.Description,
-    isPartOf: { '@id': `${siteOrigin}#website` },
     breadcrumb: { '@id': `${canonicalUrl}#breadcrumb` },
+    ...buildPageSignals({ siteOrigin, dateModified: SITE.version_date }),
     primaryImageOfPage: {
       '@type': 'ImageObject',
       url: itemImageUrl,
@@ -280,8 +282,7 @@ export const buildItemPageSchema = ({
       mainEntityOfPage: canonicalUrl,
       image: itemImageUrl,
       author: {
-        '@type': 'Organization',
-        name: "No Man's Sky Recipes",
+        '@id': `${siteOrigin}#organization`,
       },
       recipeCategory: item.Group || 'Food',
       recipeCuisine: "No Man's Sky",
@@ -325,7 +326,7 @@ export const buildItemPageSchema = ({
   if (recipeSchema) {
     itemPageStructuredData.push(recipeSchema);
   }
-  const itemPageStructuredDataJson = JSON.stringify(itemPageStructuredData).replace(/</g, '\\u003c');
+  const itemPageStructuredDataJson = serializeJsonLdGraph(itemPageStructuredData);
 
   return {
     faqQuestions,

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,4 +1,18 @@
+import { SITE } from '@config';
+
 export type JsonLdObject = Record<string, unknown>;
+
+const PAGE_ENTITY_TYPES = new Set([
+	'WebPage',
+	'ItemPage',
+	'CollectionPage',
+	'BlogPosting',
+	'Article',
+	'NewsArticle',
+	'AboutPage',
+	'ContactPage',
+	'FAQPage',
+]);
 
 export type CollectionItem = {
 	name: string;
@@ -23,6 +37,89 @@ type CollectionStructuredDataOptions = {
 };
 
 const normalizeOrigin = (origin: string): string => origin.replace(/\/$/, '');
+
+export const hasPageEntity = (schemas: JsonLdObject[]): boolean =>
+	schemas.some(
+		(schema) => typeof schema['@type'] === 'string' && PAGE_ENTITY_TYPES.has(schema['@type']),
+	);
+
+export const buildOrganizationSchema = (siteOrigin: string): JsonLdObject => {
+	const safeOrigin = normalizeOrigin(siteOrigin);
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'Organization',
+		'@id': `${safeOrigin}#organization`,
+		name: SITE.title,
+		url: `${safeOrigin}/`,
+		logo: {
+			'@type': 'ImageObject',
+			url: `${safeOrigin}${SITE.logo.url}`,
+			width: SITE.logo.width,
+			height: SITE.logo.height,
+		},
+		sameAs: SITE.social,
+	};
+};
+
+export const buildWebSiteSchema = (siteOrigin: string): JsonLdObject => {
+	const safeOrigin = normalizeOrigin(siteOrigin);
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		'@id': `${safeOrigin}#website`,
+		url: `${safeOrigin}/`,
+		name: SITE.title,
+		description: SITE.desc,
+		inLanguage: 'en',
+		publisher: { '@id': `${safeOrigin}#organization` },
+		potentialAction: {
+			'@type': 'SearchAction',
+			target: `${safeOrigin}/items?q={search_term_string}`,
+			'query-input': 'required name=search_term_string',
+		},
+	};
+};
+
+type BuildWebPageSchemaOptions = {
+	siteOrigin: string;
+	canonicalUrl: string;
+	title: string;
+	description: string;
+	dateModified: string;
+};
+
+export const buildWebPageSchema = ({
+	siteOrigin,
+	canonicalUrl,
+	title,
+	description,
+	dateModified,
+}: BuildWebPageSchemaOptions): JsonLdObject => {
+	const safeOrigin = normalizeOrigin(siteOrigin);
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		'@id': `${canonicalUrl}#webpage`,
+		url: canonicalUrl,
+		name: title,
+		description,
+		isPartOf: { '@id': `${safeOrigin}#website` },
+		dateModified,
+		isAccessibleForFree: true,
+		inLanguage: 'en',
+	};
+};
+
+export const serializeJsonLdGraph = (entities: JsonLdObject[]): string => {
+	const graph = entities.map((entity) => {
+		const { '@context': _context, ...rest } = entity;
+		return rest;
+	});
+	return JSON.stringify({
+		'@context': 'https://schema.org',
+		'@graph': graph,
+	}).replace(/</g, '\\u003c');
+};
 
 const normalizePath = (path: string): string => {
 	if (!path) return '/';

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -121,6 +121,24 @@ export const serializeJsonLdGraph = (entities: JsonLdObject[]): string => {
 	}).replace(/</g, '\\u003c');
 };
 
+type PageSignalsOptions = {
+	siteOrigin: string;
+	dateModified?: string;
+};
+
+export const buildPageSignals = ({
+	siteOrigin,
+	dateModified = SITE.version_date,
+}: PageSignalsOptions): Pick<
+	JsonLdObject,
+	'isPartOf' | 'isAccessibleForFree' | 'inLanguage' | 'dateModified'
+> => ({
+	isPartOf: { '@id': `${normalizeOrigin(siteOrigin)}#website` },
+	isAccessibleForFree: true,
+	inLanguage: 'en',
+	dateModified,
+});
+
 const normalizePath = (path: string): string => {
 	if (!path) return '/';
 	return path.startsWith('/') ? path : `/${path}`;
@@ -179,8 +197,8 @@ export const buildCollectionStructuredData = ({
 		url: canonicalUrl,
 		name: currentPage > 1 ? `${collectionName} - Page ${currentPage}` : collectionName,
 		description: collectionDescription,
-		isPartOf: { '@id': `${safeOrigin}#website` },
 		breadcrumb: { '@id': `${canonicalUrl}#breadcrumb` },
+		...buildPageSignals({ siteOrigin: safeOrigin }),
 		mainEntity: {
 			'@type': 'ItemList',
 			itemListOrder: 'https://schema.org/ItemListOrderAscending',

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -57,7 +57,6 @@ export const buildOrganizationSchema = (siteOrigin: string): JsonLdObject => {
 			width: SITE.logo.width,
 			height: SITE.logo.height,
 		},
-		sameAs: SITE.social,
 	};
 };
 

--- a/src/utils/updateChanges.ts
+++ b/src/utils/updateChanges.ts
@@ -1,5 +1,6 @@
 import newUpdate from '../datav2/new.json';
 import { formatVersionLabel } from './newUpdate';
+import { SITE } from '@config';
 
 export type ItemUpdateMeta = {
 	kind: 'added' | 'changed';
@@ -67,6 +68,16 @@ function formatValue(value: unknown): string {
 
 const addedById = new Map(payload.Items.map((item) => [String(item.Id), item]));
 const changedById = new Map(payload.ChangedItems.map((item) => [String(item.Id), item]));
+
+type NewUpdatePayloadWithGeneratedAt = NewUpdatePayload & { GeneratedAt: string };
+
+/** ISO date (YYYY-MM-DD) for schema dateModified — patch date when item was added/changed, else site version date. */
+export function getItemDateModified(id: string): string {
+	if (getItemUpdateMeta(id)) {
+		return (payload as NewUpdatePayloadWithGeneratedAt).GeneratedAt.slice(0, 10);
+	}
+	return SITE.version_date;
+}
 
 export function getItemUpdateMeta(id: string): ItemUpdateMeta | null {
 	const changed = changedById.get(id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses SchemaScore audit gaps for `nomansskyrecipes.com/` and hardens structured data site-wide.

## Changes

### Homepage (SchemaScore audit)
- `WebPage` entity with `dateModified`, `isAccessibleForFree`, `inLanguage`
- `Organization.logo` as `ImageObject` with actual dimensions (444×441)
- Single `@graph` JSON-LD block (no repeated `@context`)

### Site-wide enrichment
- `Organization` on every page so `@id` publisher references resolve
- Page signals on `CollectionPage`, `BlogPosting`, `ItemPage`, creature pages, and items hub
- `BlogPosting.publisher` linked to `Organization` via `@id`

### Item pages (latest)
- **Merged JSON-LD into `<head>`** — one `@graph` block per page (Organization + WebSite + ItemPage + FAQ/HowTo/Recipe)
- **Per-item `dateModified`** — uses patch `GeneratedAt` for added/changed items, `SITE.version_date` otherwise
- Removed body-level `<script type="application/ld+json">` from `Page.astro`
- No `sameAs` social links (no official profiles)

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` succeeds
- [x] Item pages have exactly one JSON-LD script in `<head>`
- [x] Homepage has `WebPage` + `ImageObject` logo
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3327211d-fbd8-46f2-96f9-cd702638506c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3327211d-fbd8-46f2-96f9-cd702638506c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

