### PR TITLE
Redirect ads.txt to NitroPay hosted file

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-8524094599848175, DIRECT, f08c47fec0942fa0

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "redirects": [
+    { "source": "/ads.txt", "destination": "https://api.nitropay.com/v1/ads-2507.txt", "permanent": true },
     { "source": "/portable-refiner", "destination": "/refining", "permanent": true },
     { "source": "/medium-refiner", "destination": "/refining", "permanent": true },
     { "source": "/large-refiner", "destination": "/refining", "permanent": true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a permanent Vercel redirect from `/ads.txt` → `https://api.nitropay.com/v1/ads-2507.txt` (Nitro’s recommended one-hop setup)
- Remove the static `public/ads.txt` AdSense-only file so crawlers always hit Nitro’s maintained seller list

## Notes for deploy
After this merges and ships to production, verify:
1. `https://nomansskyrecipes.com/ads.txt` 301s to the Nitro URL
2. Reply to Madison that ads.txt is live

**AdSense during transition:** Nitro’s file authorizes their Google pub, not `pub-8524094599848175`. If you want AdSense to keep working until the Nitro script cutover, add that line as a custom entry in the Nitro panel (Sites → ads.txt). Otherwise AdSense may lose authorization once the redirect is live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

