### PR TITLE
Add NitroPay ad script and CCPA/GDPR compliance

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -48,8 +48,12 @@ const navigation = [
     <div class="disclaimer">
       <p>This is a fan-made website. No Man's Sky™ and all related assets are trademarks
       of Hello Games. This site is not affiliated with or endorsed by Hello Games.</p>
-      <p class="mt-2">
+      <p class="mt-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
         <a href="/privacy" class="text-blue-500 hover:text-blue-400">Privacy Policy</a>
+        <!-- NitroPay CCPA: injects "Do Not Sell My Personal Information" for CA users -->
+        <span data-ccpa-link="1"></span>
+        <!-- NitroPay CMP: injects consent management for GDPR users -->
+        <div id="ncmp-consent-link"></div>
       </p>
     </div>
   </div>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,7 +1,7 @@
 <button
 	id="open-search"
 	type="button"
-	class="fixed bottom-4 right-4 inline-flex items-center rounded-full border border-transparent bg-blue-600 p-3 text-black shadow-xs hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+	class="fixed bottom-24 right-4 z-20 inline-flex items-center rounded-full border border-transparent bg-blue-600 p-3 text-black shadow-xs hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 	aria-label="Open search"
 	title="Search ( / or Ctrl+K )"
 >

--- a/src/components/ads/NitroAd.astro
+++ b/src/components/ads/NitroAd.astro
@@ -1,0 +1,52 @@
+---
+interface Props {
+	/** Stable placement id — must match a unique element id on the page. */
+	id: string;
+	class?: string;
+	/** Optional format override. Default is standard display. */
+	format?: 'display' | 'article' | 'smart-flex';
+	/** Optional sizes; defaults cover common desktop + mobile IAB units. */
+	sizes?: [number, number][];
+}
+
+const {
+	id,
+	class: className = '',
+	format = 'display',
+	sizes = [
+		[728, 90],
+		[970, 90],
+		[300, 250],
+		[320, 50],
+		[320, 100],
+	],
+} = Astro.props;
+
+const options = {
+	...(format !== 'display' ? { format } : {}),
+	sizes,
+	refreshTime: 30,
+	renderVisibleOnly: true,
+	report: {
+		enabled: true,
+		icon: true,
+		wording: 'Report Ad',
+		position: 'top-right',
+	},
+	...(format === 'article' ? { pageInterval: 1 } : {}),
+	...(format === 'smart-flex' ? { height: 250, smartFlexStickyTop: 16 } : {}),
+};
+
+const scriptBody = `window.nitroAds.createAd(${JSON.stringify(id)}, ${JSON.stringify(options)});`;
+---
+
+<div
+	id={id}
+	class:list={[
+		'nitro-ad mx-auto my-8 flex w-full max-w-[970px] items-center justify-center',
+		format === 'smart-flex' ? 'min-h-[250px]' : 'min-h-[90px]',
+		className,
+	]}
+	aria-hidden="true"
+></div>
+<script is:inline set:html={scriptBody} />

--- a/src/components/ads/NitroGlobalAds.astro
+++ b/src/components/ads/NitroGlobalAds.astro
@@ -1,0 +1,35 @@
+---
+/**
+ * Sitewide NitroPay formats that do not need a placeholder div.
+ * Floating video is available in the API (`format: "floating"`) but is not
+ * enabled for this site in the Placement Builder yet — add when Nitro unlocks it.
+ */
+---
+
+<script is:inline>
+	window.nitroAds.createAd('anchor-bottom', {
+		format: 'anchor-v2',
+		anchor: 'bottom',
+		anchorBgColor: 'rgb(0 0 0 / 80%)',
+		anchorClose: true,
+		anchorPersistClose: false,
+		anchorStickyOffset: 0,
+		report: {
+			enabled: true,
+			icon: true,
+			wording: 'Report Ad',
+			position: 'top-right',
+		},
+	});
+
+	window.nitroAds.createAd('interstitial', {
+		format: 'interstitial',
+		mediaQuery: '(min-width: 768px)',
+		report: {
+			enabled: true,
+			icon: true,
+			wording: 'Report Ad',
+			position: 'top-right',
+		},
+	});
+</script>

--- a/src/components/table/Table.astro
+++ b/src/components/table/Table.astro
@@ -2,6 +2,7 @@
 import '../../assets/css/tabulator.css';
 import TableHead from '@components/table/Head.astro';
 import TableCell from '@components/table/Cell.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { Image } from 'astro:assets';
 
 interface Column {
@@ -110,6 +111,7 @@ const { title, image, image_width, image_height, columns, sort = 'output', data 
       </div>
     </div>
   </div>
+  <NitroAd id="table-above" class="px-4" />
   <table id="table" data-columns={JSON.stringify(columns)} data-sort={sort}>
     <TableHead columns={columns} />
     <tbody>

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export const SITE = {
     version_date: "2026-06-03",
     version_link: "https://www.nomanssky.com/swarm-update/",
     adsense_id: 'ca-pub-8524094599848175',
+    nitropay_site_id: '2507',
     imageBaseUrl: 'https://nomansskyrecipes.com/images/items/',
     logo: {
         url: '/images/icon.png',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="astro/client" />
+
+interface NitroAdsApi {
+	createAd: (id: string, options?: Record<string, unknown>) => unknown;
+	addUserToken: (...args: unknown[]) => void;
+	queue: unknown[];
+	loaded?: boolean;
+}
+
+interface Window {
+	nitroAds: NitroAdsApi;
+}

--- a/src/layouts/GuideLayout.astro
+++ b/src/layouts/GuideLayout.astro
@@ -2,6 +2,7 @@
 import Layout from '@layouts/Layout.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import Accordion from '@components/Accordion.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { buildGuideStructuredData } from '@utils/guideStructuredData.js';
 import { getSiteOrigin } from '@utils/structuredData.js';
 import type { CollectionEntry } from 'astro:content';
@@ -98,10 +99,31 @@ const modifiedTime = (guide.data.updatedDate ?? guide.data.pubDate).toISOString(
 	<article class="mx-auto max-w-7xl px-4 py-10">
 		<div class="flex justify-center gap-8 xl:items-start">
 			<div class="w-full max-w-[680px] min-w-0">
+				<NitroAd id="guide-after-hero" class="mt-0 mb-8" />
 
-				<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
-					<slot />
+				<div id="guide-article">
+					<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
+						<slot />
+					</div>
 				</div>
+				<script is:inline>
+					window.nitroAds.createAd('guide-article', {
+						format: 'article',
+						pageInterval: 1,
+						sizes: [
+							[728, 90],
+							[300, 250],
+							[320, 50],
+							[320, 100],
+						],
+						report: {
+							enabled: true,
+							icon: true,
+							wording: 'Report Ad',
+							position: 'top-right',
+						},
+					});
+				</script>
 				<script>
 					document.querySelectorAll('#guide-content table').forEach((table) => {
 						if (table.parentElement?.classList.contains('prose-table-scroll')) return;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ import Sidebar from '@layouts/Sidebar.astro';
 import Search from '@components/Search.astro';
 import SearchModal from '@components/SearchModal.astro';
 import Footer from '@components/Footer.astro';
+import NitroGlobalAds from '@components/ads/NitroGlobalAds.astro';
 import { SITE } from '@config';
 
 export interface Props {
@@ -170,5 +171,6 @@ inject();
 		<SearchModal />
 		<Search />
 		<Footer />
+		<NitroGlobalAds />
 	</body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -129,6 +129,24 @@ inject();
 			crossorigin="anonymous"
 		></script>
 
+		<!-- NitroPay -->
+		<script is:inline data-cfasync="false">
+			/* eslint-disable prefer-rest-params -- NitroPay stock snippet queues the Arguments object. */
+			window.nitroAds = window.nitroAds || {
+				createAd: function () {
+					return new Promise((e) => {
+						window.nitroAds.queue.push(['createAd', arguments, e]);
+					});
+				},
+				addUserToken: function () {
+					window.nitroAds.queue.push(['addUserToken', arguments]);
+				},
+				queue: [],
+			};
+			/* eslint-enable prefer-rest-params */
+		</script>
+		<script is:inline data-cfasync="false" async src="https://s.nitropay.com/ads-2507.js"></script>
+
 		<!-- Google tag (gtag.js) -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=G-9GEFK3YPV3"></script>
 		<script is:inline>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -9,6 +9,7 @@ import RefinedToCreate from '@components/item/RefinedToCreate.astro';
 import CookedToCreate from '@components/item/CookedToCreate.astro';
 import UsedToCreate from '@components/item/UsedToCreate.astro';
 import ItemFaq from '@components/item/ItemFaq.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { getItemUpdateMeta } from '@utils/updateChanges';
 import { getById, findOutput, findInputFromRefiner, findInputFromCooking, findInputFromCrafting, getSlug } from '@utils/lookup.js';
 import type { Item } from '@utils/lookup.js';
@@ -452,6 +453,8 @@ const imageBaseUrl = SITE.imageBaseUrl;
     showQuantityInput={showQuantityInput}
     imageBaseUrl={imageBaseUrl}
   />
+
+  <NitroAd id="item-after-details" />
 
   <CraftingSection
     item={item}

--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -2,6 +2,7 @@
 import Layout from '@layouts/Layout.astro';
 import CategoryFilter from '@components/CategoryFilter.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
 import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
@@ -69,5 +70,6 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">{config.h1}</h1>
 	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<NitroAd id="list-after-intro" />
 	<CategoryFilter type={config.slug} basePath={categoryPath} />
 </Layout>

--- a/src/pages/calculator/index.astro
+++ b/src/pages/calculator/index.astro
@@ -3,6 +3,7 @@ import Layout from '@layouts/Layout.astro';
 import CompactCard from '@components/CompactCard.astro';
 import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { getSlug } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
 import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
@@ -63,6 +64,7 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Calculator</h1>
 	<p class="mx-auto mb-4 mt-3 max-w-3xl text-center text-sky-200/90">{intro}</p>
 	<p class="text-xl text-center mt-3 mb-8">Choose an item below to start</p>
+	<NitroAd id="calculator-after-intro" />
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
 		{
 			page.data.map((item, index) =>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Card from '../components/Card.astro';
+import NitroAd from '@components/ads/NitroAd.astro';
 import { SITE } from '@config';
 
 const cards = [
@@ -178,6 +179,8 @@ const cards = [
             Refiners | Crafting | Cooking | And more...
         </p>
     </header>
+
+    <NitroAd id="home-after-hero" class="px-4" />
 
     <main class="container w-auto mx-auto px-4 py-8">
         <div id="items" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -4,7 +4,7 @@ import Layout from '@layouts/Layout.astro';
 
 <Layout
 	title="Privacy Policy | No Man's Sky Recipes"
-	description="Read the No Man's Sky Recipes privacy policy covering analytics, ads, cookies, and your privacy choices."
+	description="Read the No Man's Sky Recipes privacy policy covering analytics, ads, cookies, CCPA, GDPR, and your privacy choices."
 	slug="privacy"
 >
   <div class="max-w-3xl mx-auto px-4 py-8">
@@ -21,43 +21,107 @@ import Layout from '@layouts/Layout.astro';
         <p>This website uses:</p>
         <ul class="list-disc pl-6 mt-2 space-y-2">
           <li>Google Analytics - to understand website traffic and usage patterns</li>
-          <li>Google AdSense - to display advertisements</li>
+          <li>NitroPay - to display advertisements and manage ad partners</li>
+          <li>Google AdSense - to display advertisements (during transition)</li>
         </ul>
-        <p class="mt-2">These services may use cookies and collect anonymous usage data. For more information about how these services handle your data, please refer to:</p>
+        <p class="mt-2">These services may use cookies and collect usage data. For more information about how these services handle your data, please refer to:</p>
         <ul class="list-disc pl-6 mt-2 space-y-2">
           <li><a href="https://policies.google.com/privacy" class="text-blue-500 hover:text-blue-400">Google Privacy Policy</a></li>
-          <li><a href="https://policies.google.com/technologies/ads" class="text-blue-500 hover:text-blue-400">Google AdSense Privacy</a></li>
+          <li><a href="https://policies.google.com/technologies/ads" class="text-blue-500 hover:text-blue-400">Google Advertising Privacy</a></li>
+          <li><a href="https://nitropay.com/privacy" class="text-blue-500 hover:text-blue-400">NitroPay Privacy Policy</a></li>
         </ul>
       </section>
 
       <section>
         <h2 class="text-2xl font-semibold mb-3">Cookies</h2>
-        <p>This website uses cookies from Google Analytics and Google AdSense. You can control or delete cookies through your browser settings.</p>
+        <p>
+          This website uses cookies from Google Analytics, NitroPay (and its advertising partners),
+          and Google AdSense. Cookies may be used for analytics, ad delivery, frequency capping,
+          fraud prevention, and remembering your privacy choices. You can control or delete cookies
+          through your browser settings.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-semibold mb-3">Advertising</h2>
+        <p>
+          Advertising on this site is served through NitroPay and its partners (and may also include
+          Google AdSense during transition). These ads:
+        </p>
+        <ul class="list-disc pl-6 mt-2 space-y-2">
+          <li>May use cookies and similar technologies to personalize content and ads</li>
+          <li>May collect and use data about your browsing activity on this and other sites</li>
+          <li>Are provided by third-party advertising networks and partners</li>
+        </ul>
+        <p class="mt-2">
+          You can learn more about how Google uses data when you use our site by visiting
+          <a href="https://policies.google.com/technologies/partner-sites" class="text-blue-500 hover:text-blue-400">Google&apos;s Privacy &amp; Terms site</a>.
+        </p>
       </section>
 
       <section>
         <h2 class="text-2xl font-semibold mb-3">Your Privacy Choices</h2>
         <ul class="list-disc pl-6 mt-2 space-y-2">
-          <li>You can opt out of Google Analytics by using the <a href="https://tools.google.com/dlpage/gaoptout" class="text-blue-500 hover:text-blue-400">Google Analytics Opt-out Browser Add-on</a></li>
-          <li>You can customize your ad preferences through <a href="https://www.google.com/settings/ads" class="text-blue-500 hover:text-blue-400">Google Ad Settings</a></li>
+          <li>
+            You can opt out of Google Analytics by using the
+            <a href="https://tools.google.com/dlpage/gaoptout" class="text-blue-500 hover:text-blue-400">Google Analytics Opt-out Browser Add-on</a>
+          </li>
+          <li>
+            You can customize Google ad preferences through
+            <a href="https://www.google.com/settings/ads" class="text-blue-500 hover:text-blue-400">Google Ad Settings</a>
+          </li>
         </ul>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-semibold mb-3">California Privacy Rights (CCPA/CPRA)</h2>
+        <p>
+          If you are a California resident, you have the right to opt out of the sale or sharing of
+          personal information for cross-context behavioral advertising. We use advertising partners
+          that may engage in activity considered a &quot;sale&quot; or &quot;sharing&quot; under
+          California law.
+        </p>
+        <p class="mt-2">
+          To exercise your right to opt out, use the &quot;Do Not Sell My Personal Information&quot;
+          link below (shown when applicable) or in the site footer:
+        </p>
+        <p class="mt-3">
+          <span data-ccpa-link="1"></span>
+        </p>
+        <p class="mt-2 text-gray-300 text-sm">
+          Categories of information that may be collected or shared in connection with advertising
+          include online identifiers (such as cookie IDs), IP address, device/browser information,
+          and browsing activity on this site. We do not intentionally collect sensitive personal
+          information for advertising purposes.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-semibold mb-3">European Privacy Rights (GDPR)</h2>
+        <p>
+          If you access this site from the European Economic Area, UK, or another region where GDPR
+          (or similar law) applies, NitroPay&apos;s consent management platform (CMP) may ask for
+          your consent before using cookies or processing personal data for personalized advertising.
+        </p>
+        <p class="mt-2">
+          You can review or update your cookie and advertising consent preferences at any time using
+          the consent link in the site footer (shown when applicable), or:
+        </p>
+        <p class="mt-3">
+          <button
+            type="button"
+            class="text-blue-500 hover:text-blue-400 underline bg-transparent border-0 p-0 cursor-pointer text-base font-nms"
+            onclick="window.__cmp && window.__cmp('showModal')"
+          >
+            Update cookie preferences
+          </button>
+        </p>
       </section>
 
       <section>
         <h2 class="text-2xl font-semibold mb-3">Changes to This Policy</h2>
         <p>We may update this privacy policy from time to time. We will notify you of any changes by posting the new policy on this page.</p>
-        <p class="mt-2">Last updated: April 12, 2026</p>
-      </section>
-
-      <section>
-        <h2 class="text-2xl font-semibold mb-3">Advertising</h2>
-        <p>This site uses Google AdSense to display advertisements. These ads:</p>
-        <ul class="list-disc pl-6 mt-2 space-y-2">
-          <li>May use cookies to personalize content and ads</li>
-          <li>May collect and use data about your browsing activity</li>
-          <li>Are provided by Google and its partners</li>
-        </ul>
-        <p class="mt-2">You can learn more about how Google uses data when you use our site by visiting <a href="https://policies.google.com/technologies/partner-sites" class="text-blue-500 hover:text-blue-400">Google's Privacy & Terms site</a>.</p>
+        <p class="mt-2">Last updated: July 16, 2026</p>
       </section>
 
       <section class="text-2xl">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Install NitroPay site `2507` head script in `Layout.astro`
- Add CCPA `data-ccpa-link` and CMP `#ncmp-consent-link` anchors in the site footer
- Expand `/privacy` with Nitro advertising disclosures plus CCPA and GDPR sections
- Wire placements from the Nitro API + Placement Builder:

### Global (`NitroGlobalAds.astro`)
- `anchor-bottom` (`anchor-v2`, all devices — builder mediaQuery had excluded mobile)
- `interstitial` (tablet + desktop, `min-width: 768px`)

### In-content (`NitroAd.astro`)
- Home: `home-after-hero`
- Item pages: `item-after-details`
- Blog/guides: `guide-after-hero` + `guide-article` (article format)
- Refining/cooking/crafting tables: `table-above`
- Category lists: `list-after-intro`
- Calculator: `calculator-after-intro`

### UX
- Raised search FAB above the bottom anchor (`bottom-24`)

## Notes
- Floating video exists in the API (`format: "floating"`) but is not in your Placement Builder yet — ask Madison to enable it if you want that unit
- AdSense script is still loaded during transition; remove when Nitro fill looks healthy
- After deploy: check Nitro setup boxes, verify with `?nitro_demo=1` / `?nitroads_debug=1`

## Verify
- `?usp_debug=1` → CCPA link
- `?gdpr_debug=1` → CMP link
- `?nitro_demo=1` → placeholder creatives in slots
- Confirm `ads-2507.js` loads and anchor appears bottom of viewport
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

