### PR TITLE
Remove AdSense and move blog ad into sidebar

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,6 @@ export const SITE = {
     version_name: "Swarm",
     version_date: "2026-06-03",
     version_link: "https://www.nomanssky.com/swarm-update/",
-    adsense_id: 'ca-pub-8524094599848175',
     nitropay_site_id: '2507',
     imageBaseUrl: 'https://nomansskyrecipes.com/images/items/',
     logo: {

--- a/src/layouts/GuideLayout.astro
+++ b/src/layouts/GuideLayout.astro
@@ -99,8 +99,6 @@ const modifiedTime = (guide.data.updatedDate ?? guide.data.pubDate).toISOString(
 	<article class="mx-auto max-w-7xl px-4 py-10">
 		<div class="flex justify-center gap-8 xl:items-start">
 			<div class="w-full max-w-[680px] min-w-0">
-				<NitroAd id="guide-after-hero" class="mt-0 mb-8" />
-
 				<div id="guide-article">
 					<div id="guide-content" class="prose prose-invert max-w-none prose-headings:text-white prose-strong:text-white prose-li:text-sky-100/90 prose-p:text-sky-100/90">
 						<slot />
@@ -164,8 +162,13 @@ const modifiedTime = (guide.data.updatedDate ?? guide.data.pubDate).toISOString(
 			)}
 			</div>
 
-			{tocHeadings.length > 0 && (
-				<aside class="hidden xl:block w-60 shrink-0 self-start sticky top-4 h-fit">
+			<aside class="hidden xl:block w-[300px] shrink-0 self-start sticky top-4 h-fit space-y-4">
+				<NitroAd
+					id="guide-sidebar"
+					class="my-0 max-w-[300px]"
+					sizes={[[300, 250]]}
+				/>
+				{tocHeadings.length > 0 && (
 					<div class="rounded-lg border border-sky-900/70 bg-sky-950/30 p-4">
 						<h2 class="mt-0 mb-3 text-lg font-semibold text-white">On this page</h2>
 						<ul class="space-y-2 text-sm list-none p-0" id="blog-toc-links">
@@ -182,8 +185,8 @@ const modifiedTime = (guide.data.updatedDate ?? guide.data.pubDate).toISOString(
 							))}
 						</ul>
 					</div>
-				</aside>
-			)}
+				)}
+			</aside>
 		</div>
 	</article>
 </Layout>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -124,12 +124,6 @@ inject();
 			crossorigin="anonymous"
 		/>
 
-		<script
-			async
-			src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8524094599848175"
-			crossorigin="anonymous"
-		></script>
-
 		<!-- NitroPay -->
 		<script is:inline data-cfasync="false">
 			/* eslint-disable prefer-rest-params -- NitroPay stock snippet queues the Arguments object. */
@@ -161,7 +155,6 @@ inject();
 		</script>
 
 		<meta name="robots" content={robots} />
-		<meta name="google-adsense-account" content="ca-pub-8524094599848175" />
 		<script type="application/ld+json" set:html={mergedStructuredDataJson}></script>
 	</head>
 	<body class={`h-full overflow-x-hidden m-0 ${slug === '/' ? 'home' : ''}`}>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -22,12 +22,10 @@ import Layout from '@layouts/Layout.astro';
         <ul class="list-disc pl-6 mt-2 space-y-2">
           <li>Google Analytics - to understand website traffic and usage patterns</li>
           <li>NitroPay - to display advertisements and manage ad partners</li>
-          <li>Google AdSense - to display advertisements (during transition)</li>
         </ul>
         <p class="mt-2">These services may use cookies and collect usage data. For more information about how these services handle your data, please refer to:</p>
         <ul class="list-disc pl-6 mt-2 space-y-2">
           <li><a href="https://policies.google.com/privacy" class="text-blue-500 hover:text-blue-400">Google Privacy Policy</a></li>
-          <li><a href="https://policies.google.com/technologies/ads" class="text-blue-500 hover:text-blue-400">Google Advertising Privacy</a></li>
           <li><a href="https://nitropay.com/privacy" class="text-blue-500 hover:text-blue-400">NitroPay Privacy Policy</a></li>
         </ul>
       </section>
@@ -35,9 +33,9 @@ import Layout from '@layouts/Layout.astro';
       <section>
         <h2 class="text-2xl font-semibold mb-3">Cookies</h2>
         <p>
-          This website uses cookies from Google Analytics, NitroPay (and its advertising partners),
-          and Google AdSense. Cookies may be used for analytics, ad delivery, frequency capping,
-          fraud prevention, and remembering your privacy choices. You can control or delete cookies
+          This website uses cookies from Google Analytics and NitroPay (and its advertising
+          partners). Cookies may be used for analytics, ad delivery, frequency capping, fraud
+          prevention, and remembering your privacy choices. You can control or delete cookies
           through your browser settings.
         </p>
       </section>
@@ -45,18 +43,13 @@ import Layout from '@layouts/Layout.astro';
       <section>
         <h2 class="text-2xl font-semibold mb-3">Advertising</h2>
         <p>
-          Advertising on this site is served through NitroPay and its partners (and may also include
-          Google AdSense during transition). These ads:
+          Advertising on this site is served through NitroPay and its partners. These ads:
         </p>
         <ul class="list-disc pl-6 mt-2 space-y-2">
           <li>May use cookies and similar technologies to personalize content and ads</li>
           <li>May collect and use data about your browsing activity on this and other sites</li>
           <li>Are provided by third-party advertising networks and partners</li>
         </ul>
-        <p class="mt-2">
-          You can learn more about how Google uses data when you use our site by visiting
-          <a href="https://policies.google.com/technologies/partner-sites" class="text-blue-500 hover:text-blue-400">Google&apos;s Privacy &amp; Terms site</a>.
-        </p>
       </section>
 
       <section>
@@ -65,10 +58,6 @@ import Layout from '@layouts/Layout.astro';
           <li>
             You can opt out of Google Analytics by using the
             <a href="https://tools.google.com/dlpage/gaoptout" class="text-blue-500 hover:text-blue-400">Google Analytics Opt-out Browser Add-on</a>
-          </li>
-          <li>
-            You can customize Google ad preferences through
-            <a href="https://www.google.com/settings/ads" class="text-blue-500 hover:text-blue-400">Google Ad Settings</a>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove Google AdSense loader/meta now that NitroPay placements are live
- Move the blog `300x250` from above the article into the sticky right sidebar (above the TOC)
- Update privacy policy copy to drop AdSense transition language

## Verify
- Blog/guides at `xl+`: sidebar shows Nitro 300x250 above “On this page”
- No AdSense / “Discover more” units (`?nitro_demo=1` still shows Nitro placeholders)
- Optional: remove the custom AdSense line from the Nitro ads.txt panel
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d11f2a-46b6-46fd-8576-9cbaf22bcd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

