### PR TITLE
seo: titles, metadata, and internal links (2026-08-25 dry run)

### DIFF
--- a/src/config/categories.ts
+++ b/src/config/categories.ts
@@ -80,12 +80,12 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	fish: {
 		slug: 'fish',
 		h1: 'Fish',
-		metaTitle: 'Fish',
+		metaTitle: 'NMS Fish Recipes & Bait List',
 		idLabel: 'Fish Item',
 		description:
-			"A list of fish for No Man's Sky. Our guide has everything you need to take your game to the next level.",
+			"NMS fish recipes and bait list. Browse aquatic catches, chum and lure recipes, and what you can cook from each fish in No Man's Sky in 2026.",
 		intro:
-			'Fish items include aquatic catches, bait outcomes, and ocean-specific resources used in recipes.',
+			'Fish items include aquatic catches, bait outcomes, and ocean-specific resources used in recipes. See the [fishing guide](/blog/no-mans-sky-fishing-guide/) and [cooking recipes](/cooking/).',
 		datasets: ['Fish'],
 		idStrategy: 'props',
 	},
@@ -103,14 +103,14 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	raw: {
 		slug: 'raw',
 		h1: 'Raw Materials',
-		metaTitle: 'Raw Materials',
+		metaTitle: 'NMS Materials List & Raw Resources',
 		idLabel: 'Raw Material',
 		description:
-			"Browse No Man's Sky raw materials, foundational resources, and ingredient pages for crafting, refining, cooking, and upgrade chains.",
+			"No Man's Sky materials list: raw resources for crafting, refining, cooking, and upgrades. Open each material page for refine and craft recipes.",
 		pageDescription:
 			"Browse No Man's Sky raw materials, base resources, and mining ingredients used in crafting, refining, cooking, and technology upgrades.",
 		intro:
-			'Browse No Man\u2019s Sky raw materials used in crafting, refining, cooking, and upgrade chains. Track foundational resources, gather ingredients, and jump into the recipes they unlock.',
+			'Browse No Man\u2019s Sky raw materials used in crafting, refining, cooking, and upgrade chains. Track foundational resources, gather ingredients, and jump into the recipes they unlock. See [refiner recipes](/refining/) and the [crafting guide](/crafting-guide/).',
 		pageIntro:
 			"Raw materials are the foundation of crafting, refining, and upgrades in No Man's Sky.",
 		datasets: ['RawMaterials'],
@@ -119,11 +119,12 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	food: {
 		slug: 'food',
 		h1: 'Food',
-		metaTitle: 'Food',
+		metaTitle: 'NMS Food Recipes & Cooking Guide',
 		idLabel: 'Food Item',
-		description: "A list of food items for No Man's Sky. Browse all edible products and ingredients.",
+		description:
+			"No Man's Sky food recipes and cooking ingredients. Browse edible products, nutrient processor recipes, and cooking chains from bait to baked goods.",
 		intro:
-			"Food items power cooking recipes, consumables, and nutrient processing chains in No Man's Sky.",
+			"Food items power [cooking recipes](/cooking/), consumables, and nutrient processing chains in No Man's Sky.",
 		datasets: ['Food'],
 		idStrategy: 'props',
 		firstPagePath: '/food',
@@ -131,11 +132,12 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	exocraft: {
 		slug: 'exocraft',
 		h1: 'Exocraft',
-		metaTitle: 'Exocraft',
+		metaTitle: 'NMS Exocraft List & How to Get',
 		idLabel: 'Exocraft Item',
 		description:
-			"A list of exocraft items for No Man's Sky. Our guide has everything you need to take your game to the next level.",
-		intro: 'Exocraft items support planetary vehicles with fuel, modules, and specialized components.',
+			'NMS Exocraft list: vehicles, fuel, radar, and modules. How to get each Exocraft item, what it crafts, and the recipes tied to planetary vehicles.',
+		intro:
+			'Exocraft items support planetary vehicles with fuel, modules, and specialized components. See [technology upgrades](/technology/).',
 		datasets: ['Exocraft'],
 		idStrategy: 'props',
 	},
@@ -190,12 +192,12 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	technology: {
 		slug: 'technology',
 		h1: 'Technology',
-		metaTitle: 'Technology Items',
+		metaTitle: 'NMS Technology List & Blueprints',
 		idLabel: 'Technology Item',
 		description:
-			"A list of technology items for No Man's Sky. Our guide has everything you need to take your game to the next level.",
+			'NMS technology list: suit, ship, multi-tool, and base blueprints. Browse technology items, modules, and the recipes that unlock each upgrade.',
 		intro:
-			'Technology items power your suit, ship, multitool, and base systems with specialized upgrades and devices.',
+			'Technology items power your suit, ship, multitool, and base systems with specialized upgrades and devices. Browse [upgrade modules](/upgrades/) and the [crafting guide](/crafting-guide/).',
 		datasets: ['ConstructedTechnology', 'Technology', 'TechnologyModule'],
 		idStrategy: 'props',
 		idSort: true,

--- a/src/content/blog/best-no-mans-sky-refiner-recipes.md
+++ b/src/content/blog/best-no-mans-sky-refiner-recipes.md
@@ -1,6 +1,6 @@
 ---
-title: "Best No Man's Sky Refiner Recipes for Nanites, Units, and Fast Progress"
-description: "The best NMS refiner recipes for nanites, units, and chromatic metal — with exact quantities, ratios, and which refiner you actually need."
+title: "NMS Refiner Recipes: Nanites & Units"
+description: "NMS refiner recipes for nanites, units, and chromatic metal. Exact ratios, Chlorine and Oxygen loops, and which refiner size you actually need."
 pubDate: 2024-10-09
 updatedDate: 2024-10-09
 heroImage: "/images/blog/refiner-recipes.webp"
@@ -12,6 +12,8 @@ tags:
   - crafting
 featured: true
 relatedLinks:
+  - label: "Chromatic Metal recipes"
+    href: "/raw/STELLAR2/"
   - label: "Browse all refiner recipes"
     href: "/refining"
   - label: "Open the crafting calculator"

--- a/src/content/blog/is-no-mans-sky-worth-it-2026.md
+++ b/src/content/blog/is-no-mans-sky-worth-it-2026.md
@@ -1,6 +1,6 @@
 ---
-title: "Is No Man's Sky Worth It in 2026?"
-description: "No Man's Sky in 2026 is barely recognizable from its 2016 launch. 45+ free updates later, here's who should buy it and who should skip it."
+title: "No Man's Sky Review 2026: Worth It?"
+description: "No Man's Sky review 2026: is it worth it after 45+ free updates? Who should buy, who should skip, and what the game actually is like in 2026."
 pubDate: 2026-04-13
 updatedDate: 2026-04-13
 category: "blog"
@@ -12,6 +12,8 @@ tags:
 heroImage: "/images/blog/is-nms-worth-it-2026.webp"
 featured: false
 relatedLinks:
+  - label: "Returning player guide 2026"
+    href: "/blog/no-mans-sky-returning-player-guide-2026/"
   - label: "All refiner recipes"
     href: "/refining"
   - label: "Crafting calculator"

--- a/src/content/blog/nms-swarm-expedition-guide.md
+++ b/src/content/blog/nms-swarm-expedition-guide.md
@@ -1,6 +1,6 @@
 ---
-title: "No Man's Sky Swarm Expedition Guide: Factions, Rewards, and How to Beat the Hive of Glass"
-description: "Complete guide to NMS Expedition 22: The Swarm. Join Royals, Sages, or Weavers, earn the Direwasp armor set, and take down the Hive of Glass."
+title: "NMS Swarm Expedition Guide & Rewards"
+description: "NMS Swarm expedition (Expedition 22) walkthrough: factions, rewards, phases, and Hive of Glass boss tips. Includes Corrupted Ichor and Direwasp loot."
 pubDate: 2026-06-04
 updatedDate: 2026-06-04
 heroImage: "/images/blog/nms-swarm-expedition-guide.webp"
@@ -14,6 +14,8 @@ tags:
   - update-6-4
 featured: false
 relatedLinks:
+  - label: "Returning player guide 2026"
+    href: "/blog/no-mans-sky-returning-player-guide-2026/"
   - label: "New items in update 6.4"
     href: "/new"
   - label: "Gravitino Coil guide"

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -31,9 +31,10 @@ import { SITE } from '@config';
 interface Props {
   item: Item;
   schemaResult: ItemPageSchemaResult;
+  relatedLinks?: Array<{ label: string; href: string }>;
 }
 
-const { item, schemaResult } = Astro.props;
+const { item, schemaResult, relatedLinks = [] } = Astro.props;
 const itemUpdateMeta = getItemUpdateMeta(item.Id);
 const normalizedSlug = (item.Slug ?? '').replace(/^\/+/, '').replace(/^cooking\//, 'food/');
 const categorySlug = normalizedSlug.split('/')[0] || 'items';
@@ -453,6 +454,17 @@ const imageBaseUrl = SITE.imageBaseUrl;
     showQuantityInput={showQuantityInput}
     imageBaseUrl={imageBaseUrl}
   />
+
+  {relatedLinks.length > 0 && (
+    <p class="mx-auto mb-4 max-w-4xl px-4 text-center text-sky-200/90">
+      {relatedLinks.map((link, index) => (
+        <>
+          {index > 0 ? ' · ' : ''}
+          <a href={link.href} class="text-cyan-300 underline hover:text-cyan-200">{link.label}</a>
+        </>
+      ))}
+    </p>
+  )}
 
   <NitroAd id="item-after-details" />
 

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -104,7 +104,7 @@ if (!item) {
 	return Astro.redirect('/404');
 }
 
-const { title, description } = buildItemMeta(item, config.idLabel);
+const { title, description, relatedLinks } = buildItemMeta(item, config.idLabel);
 const ogImage = `${SITE.imageBaseUrl}${item.Icon}`;
 const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
 const schemaResult = buildItemPageSchema({
@@ -114,5 +114,5 @@ const schemaResult = buildItemPageSchema({
 ---
 
 <Layout {title} {description} slug={config.slug} {ogImage} structuredData={schemaResult.structuredData}>
-	<Page item={item} schemaResult={schemaResult} />
+	<Page item={item} schemaResult={schemaResult} relatedLinks={relatedLinks} />
 </Layout>

--- a/src/pages/[category]/[page].astro
+++ b/src/pages/[category]/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls, parseIntroLinks } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
@@ -81,7 +81,15 @@ const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">{config.h1}</h1>
-	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">
+		{parseIntroLinks(intro).map((segment) =>
+			segment.href ? (
+				<a href={segment.href} class="text-cyan-300 underline hover:text-cyan-200">{segment.text}</a>
+			) : (
+				segment.text
+			)
+		)}
+	</p>
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
 		{
 			page.data.map((item, index) => (

--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '@components/Breadcrumbs.astro';
 import NitroAd from '@components/ads/NitroAd.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls, parseIntroLinks } from '@utils/seo.js';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
 
@@ -69,7 +69,15 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">{config.h1}</h1>
-	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">
+		{parseIntroLinks(intro).map((segment) =>
+			segment.href ? (
+				<a href={segment.href} class="text-cyan-300 underline hover:text-cyan-200">{segment.text}</a>
+			) : (
+				segment.text
+			)
+		)}
+	</p>
 	<NitroAd id="list-after-intro" />
 	<CategoryFilter type={config.slug} basePath={categoryPath} />
 </Layout>

--- a/src/pages/calculator/index.astro
+++ b/src/pages/calculator/index.astro
@@ -36,7 +36,7 @@ const structuredData = buildCollectionStructuredData({
 	siteOrigin,
 	canonicalUrl,
 	collectionName: 'Crafting Calculator',
-	collectionDescription: 'A calculator to help your farming efforts by calculating exactly what you need to craft any item.',
+	collectionDescription: 'NMS crafting calculator: pick a product and get exact ingredients, farm totals, and reverse-craft paths so you know what to gather first in NMS.',
 	collectionPath: '/calculator',
 	currentPage: page.currentPage,
 	items: itemListElements,
@@ -47,8 +47,8 @@ const intro = buildCategoryIntro(
 	page.currentPage,
 	page.lastPage
 );
-const baseDescription = 'A calculator to help your farming efforts by calculating exactly what you need to craft any item.';
-const { title, description } = buildPaginatedMeta('Crafting Calculator', baseDescription, page.currentPage, page.lastPage);
+const baseDescription = 'NMS crafting calculator: pick a product and get exact ingredients, farm totals, and reverse-craft paths so you know what to gather first in NMS.';
+const { title, description } = buildPaginatedMeta('NMS Crafting Calculator & Planner', baseDescription, page.currentPage, page.lastPage);
 const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 ---
 
@@ -63,6 +63,9 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-2">Crafting Calculator</h1>
 	<p class="mx-auto mb-4 mt-3 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="mx-auto mb-4 max-w-3xl text-center text-sky-200/90">
+		Open the <a href="/calculator/planner/" class="text-cyan-300 underline hover:text-cyan-200">recipe planner</a> or the <a href="/crafting-guide/" class="text-cyan-300 underline hover:text-cyan-200">crafting guide</a>.
+	</p>
 	<p class="text-xl text-center mt-3 mb-8">Choose an item below to start</p>
 	<NitroAd id="calculator-after-intro" />
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">

--- a/src/pages/crafting-guide/index.astro
+++ b/src/pages/crafting-guide/index.astro
@@ -94,7 +94,7 @@ const structuredData = buildCollectionStructuredData({
 		<p class="mx-auto mb-6 max-w-3xl text-center text-sky-200/90">
 			See the <a href="/calculator/" class="text-cyan-300 underline hover:text-cyan-200">crafting calculator</a> and <a href="/refining/" class="text-cyan-300 underline hover:text-cyan-200">refiner recipes</a>.
 		</p>
-		<Table>
+		<Table
 			title="Crafting"
 			image="crafting-guide"
 			image_width={100}

--- a/src/pages/crafting-guide/index.astro
+++ b/src/pages/crafting-guide/index.astro
@@ -64,7 +64,7 @@ const data = products.map(createArray).filter((item): item is TableRow => item !
 const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
 const canonicalUrl = new URL('/crafting-guide', siteOrigin).toString();
 const baseDescription =
-	"Browse the No Man's Sky crafting guide for product recipes, ingredient chains, unit values, and step-by-step crafting paths.";
+	"No Man's Sky crafting recipes, crafting tree, and ingredient chart. Browse product recipes, unit values, and step-by-step craft paths in one list.";
 const itemListElements = data.slice(0, 25).map((row, index) => {
 	const outputItem = getById(row.output.id);
 	return {
@@ -85,13 +85,16 @@ const structuredData = buildCollectionStructuredData({
 ---
 
 <Layout
-	title="Crafting Guide | No Man's Sky Recipes"
+	title="NMS Crafting Recipes, Tree & Chart | No Man's Sky Recipes"
 	description={baseDescription}
 	slug="crafting-guide"
 	ogImage={`${SITE.website}/images/crafting.webp`}
 	structuredData={structuredData}
 >
-		<Table
+		<p class="mx-auto mb-6 max-w-3xl text-center text-sky-200/90">
+			See the <a href="/calculator/" class="text-cyan-300 underline hover:text-cyan-200">crafting calculator</a> and <a href="/refining/" class="text-cyan-300 underline hover:text-cyan-200">refiner recipes</a>.
+		</p>
+		<Table>
 			title="Crafting"
 			image="crafting-guide"
 			image_width={100}

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -21,6 +21,62 @@ const normalizePath = (path: string): string => {
 
 type ItemMetaInput = Pick<Item, 'Id' | 'Name' | 'Description' | 'Group' | 'Slug'>;
 
+export type ItemRelatedLink = {
+	label: string;
+	href: string;
+};
+
+export type IntroSegment = {
+	text: string;
+	href?: string;
+};
+
+type ItemMetaOverride = {
+	title: string;
+	description: string;
+	relatedLinks?: ItemRelatedLink[];
+};
+
+const SITE_TITLE_SUFFIX = " | No Man's Sky Recipes";
+
+const ITEM_META_OVERRIDES: Record<string, ItemMetaOverride> = {
+	GASGIANT1: {
+		title: 'Crystallized Helium NMS Recipe',
+		description:
+			'Crystallized Helium (Crystallised) NMS: how to get it on gas giants, refine Lithium plus Quartzite, and every recipe that uses the resource.',
+	},
+	STELLAR2: {
+		title: 'Chromatic Metal NMS Recipe & Ratios',
+		description:
+			'Chromatic Metal NMS recipe: convert Copper, Cadmium, Emeril, or Indium in a refiner. Best ratios plus Activated metal and Large Refiner tricks.',
+		relatedLinks: [
+			{ label: 'best refiner recipes', href: '/blog/best-no-mans-sky-refiner-recipes/' },
+		],
+	},
+};
+
+export const parseIntroLinks = (intro: string): IntroSegment[] => {
+	const segments: IntroSegment[] = [];
+	const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null = linkPattern.exec(intro);
+
+	while (match) {
+		if (match.index > lastIndex) {
+			segments.push({ text: intro.slice(lastIndex, match.index) });
+		}
+		segments.push({ text: match[1], href: match[2] });
+		lastIndex = linkPattern.lastIndex;
+		match = linkPattern.exec(intro);
+	}
+
+	if (lastIndex < intro.length) {
+		segments.push({ text: intro.slice(lastIndex) });
+	}
+
+	return segments;
+};
+
 const normalizeCategoryLabel = (value: string | undefined): string =>
 	normalizeWhitespace(value ?? '')
 		.toLowerCase()
@@ -186,7 +242,16 @@ const buildItemTitle = (item: ItemMetaInput, categoryLabel: string, uniquenessHi
 export const buildItemMeta = (
 	item: ItemMetaInput,
 	categoryLabel: string
-): { title: string; description: string } => {
+): { title: string; description: string; relatedLinks?: ItemRelatedLink[] } => {
+	const override = ITEM_META_OVERRIDES[item.Id];
+	if (override) {
+		return {
+			title: `${override.title}${SITE_TITLE_SUFFIX}`,
+			description: override.description,
+			...(override.relatedLinks ? { relatedLinks: override.relatedLinks } : {}),
+		};
+	}
+
 	const normalizedDescription = normalizeDescriptionHint(item.Description) ?? '';
 	const uniquenessHint = buildItemUniquenessHint(item, categoryLabel);
 	const title = buildItemTitle(item, categoryLabel, uniquenessHint);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Titles, metadata, and missing internal links only. No new blog posts. No body-copy rewrites except adding a missing internal link. GASGIANT1 and STELLAR2 are one-off `buildItemMeta` overrides — other raw items are unchanged.

## Data windows

- **GSC property:** `sc-domain:nomansskyrecipes.com`
- **Current:** 2026-07-26 to 2026-08-22
- **Prior:** 2026-06-28 to 2026-07-25
- **DataForSEO:** used only for current SERP/title context (US desktop, 2026-08-26). Not used as ranking evidence. GSC positions below are from the current window unless noted as prior→current.

`GuideLayout` / `buildPaginatedMeta` append ` | No Man's Sky Recipes` (23 chars). Title **fields** are sized so the live `<title>` lands at 50–60 characters. Item overrides in `buildItemMeta` skip the category-label segment so GASGIANT1/STELLAR2 stay ≤60 with brand.

**Out of scope:** `/cooking` vs `/cooking/` slash canonical.

## Page-by-page

### 1. `/blog/nms-swarm-expedition-guide/`
- **GSC:** 50,591→13,996 imps (−36,595), pos 7.91
- **Current title:** `No Man's Sky Swarm Expedition Guide: Factions, Rewards, and How to Beat the Hive of Glass | No Man's Sky Recipes` (112 chars)
- **Proposed field:** `NMS Swarm Expedition Guide & Rewards`
- **Proposed live:** `NMS Swarm Expedition Guide & Rewards | No Man's Sky Recipes` (59)
- **Internal link:** Returning player guide 2026 → `/blog/no-mans-sky-returning-player-guide-2026/`
- **DataForSEO (`nms swarm expedition`):** official Swarm Update is #1; this URL currently appears with a truncated title (`Factions, Rewards, and How to Beat the Hive of Glass`). Cited in AI Overview.

### 2. `/crafting-guide/`
- **GSC:** 4,124 imps, pos 11.62, 70 clicks
- **Current title:** `Crafting Guide | No Man's Sky Recipes`
- **Proposed field:** `NMS Crafting Recipes, Tree & Chart`
- **Proposed live:** `NMS Crafting Recipes, Tree & Chart | No Man's Sky Recipes` (57)
- **Internal links:** crafting calculator → `/calculator/` ; refiner recipes → `/refining/`

### 3. `/food/`
- **GSC:** 2,655 imps, pos 18.66, CTR 0.49%
- **Current title:** `Food | No Man's Sky Recipes`
- **Proposed field:** `NMS Food Recipes & Cooking Guide`
- **Proposed live:** `NMS Food Recipes & Cooking Guide | No Man's Sky Recipes` (55)
- **Internal link:** cooking recipes → `/cooking/`

### 4. `/raw/`
- **GSC:** 2,359 imps, pos 17.76
- **Current title:** `Raw Materials | No Man's Sky Recipes`
- **Proposed field:** `NMS Materials List & Raw Resources`
- **Proposed live:** `NMS Materials List & Raw Resources | No Man's Sky Recipes` (57)
- **Internal links:** refiner recipes → `/refining/` ; crafting guide → `/crafting-guide/`

### 5. `/technology/`
- **GSC:** 1,097 imps, pos 16.30
- **Current title:** `Technology Items | No Man's Sky Recipes`
- **Proposed field:** `NMS Technology List & Blueprints`
- **Proposed live:** `NMS Technology List & Blueprints | No Man's Sky Recipes` (55)
- **Internal links:** upgrade modules → `/upgrades/` ; crafting guide → `/crafting-guide/`

### 6. `/calculator/`
- **GSC:** 988 imps, pos 12.93, CTR 12.65%
- **Current title:** `Crafting Calculator | No Man's Sky Recipes`
- **Proposed field:** `NMS Crafting Calculator & Planner`
- **Proposed live:** `NMS Crafting Calculator & Planner | No Man's Sky Recipes` (56)
- **Internal links (above card grid):** recipe planner → `/calculator/planner/` ; crafting guide → `/crafting-guide/`

### 7. `/raw/GASGIANT1/` (Crystallized Helium)
- **GSC:** 8,378→5,091 imps (−3,287)
- **Current title:** `Crystallised Helium | Raw Material | No Man's Sky Recipes`
- **Proposed field:** `Crystallized Helium NMS Recipe` (US spelling matches GSC queries; description keeps Crystallised)
- **Proposed live:** `Crystallized Helium NMS Recipe | No Man's Sky Recipes` (53)
- **No extra body paragraph**
- **DataForSEO (`crystallized helium nms`):** US queries use Crystallized; wiki/Fandom title uses Crystallised. This URL currently shows as `Crystallised Helium | Raw Material`.

### 8. `/blog/best-no-mans-sky-refiner-recipes/`
- **GSC:** 6,725→5,135 imps (−1,590)
- **Current title:** `Best No Man's Sky Refiner Recipes for Nanites, Units, and Fast Progress | No Man's Sky Recipes` (94 chars)
- **Proposed field:** `NMS Refiner Recipes: Nanites & Units`
- **Proposed live:** `NMS Refiner Recipes: Nanites & Units | No Man's Sky Recipes` (59)
- **Internal link:** Chromatic Metal recipes → `/raw/STELLAR2/`
- **DataForSEO (`nms refiner recipes`):** `/refining/` currently ranks #1 with title `Refining`. Competing titles are recipe-list phrasing (`Complete Refining Recipe List for No Man's Sky 2026`). This blog URL was not in that top-10 snapshot.

### 9. `/blog/is-no-mans-sky-worth-it-2026/`
- **GSC:** 6,952→5,535 imps (−1,417)
- **Current title:** `Is No Man's Sky Worth It in 2026? | No Man's Sky Recipes`
- **Proposed field:** `No Man's Sky Review 2026: Worth It?`
- **Proposed live:** `No Man's Sky Review 2026: Worth It? | No Man's Sky Recipes` (58)
- **Internal link:** Returning player guide 2026 → `/blog/no-mans-sky-returning-player-guide-2026/`
- **DataForSEO (`is no mans sky worth it 2026`):** Reddit #1 uses `worth buying now? (April 2026)`. This URL currently shows `Is No Man's Sky Worth It in 2026?` and is cited in AI Overview. Competing titles use `Review 2026` / `Worth It In 2026`.

### 10. `/raw/STELLAR2/` (Chromatic Metal)
- **GSC:** 7,625→6,117 imps (−1,508). Query `chromatic metal nms`: 542 imps, pos 9.37, CTR 0.37%
- **Current title:** `Chromatic Metal | Raw Material | No Man's Sky Recipes`
- **Proposed field:** `Chromatic Metal NMS Recipe & Ratios`
- **Proposed live:** `Chromatic Metal NMS Recipe & Ratios | No Man's Sky Recipes` (58)
- **Internal link:** best refiner recipes → `/blog/best-no-mans-sky-refiner-recipes/`
- **DataForSEO (`chromatic metal nms`):** page-1 titles are how-to/wiki (`Chromatic Metal - No Man's Sky Wiki`). This URL was not in that top-10 snapshot. AI Overview emphasizes refine ratios (Copper/Cadmium/Emeril/Indium).

### 11. `/exocraft/`
- **GSC:** 624 imps, pos 12.04
- **Current title:** `Exocraft | No Man's Sky Recipes`
- **Proposed field:** `NMS Exocraft List & How to Get`
- **Proposed live:** `NMS Exocraft List & How to Get | No Man's Sky Recipes` (53)
- **Internal link:** technology upgrades → `/technology/`

### 12. `/fish/`
- **GSC:** 532 imps, pos 14.94
- **Current title:** `Fish | No Man's Sky Recipes`
- **Proposed field:** `NMS Fish Recipes & Bait List`
- **Proposed live:** `NMS Fish Recipes & Bait List | No Man's Sky Recipes` (51)
- **Internal links:** fishing guide → `/blog/no-mans-sky-fishing-guide/` ; cooking recipes → `/cooking/`

## Scope check

- Branch: `seo/2026-08-25-dry-run` (not `main`)
- Files: titles, metadata, internal-link wiring only (`seo.ts` overrides, category intros, blog frontmatter, two index pages, item related-link render)
- No merge

## Verification

All 12 live titles decode to 51–59 characters. Control item `/raw/FUEL1/` still uses `Carbon | Raw Material | No Man's Sky Recipes`. Browser pass clicked the new intro/related links; Chromatic Metal is the only item page that gained a related link.

[Swarm guide new tab title](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswarm-guide-new-title.webp)
[Crafting guide intro links](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcrafting-guide-intro-links.webp)
[Raw materials intro links](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fraw-materials-intro-links.webp)
[Calculator planner and crafting guide links](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalculator-planner-links.webp)
[Crystallized Helium title override](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcrystallized-helium-title.webp)
[Chromatic Metal related link](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchromatic-metal-related-link.webp)
[Refiner recipes and review titles](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefiner-recipes-and-review-titles.webp)
[Technology intro links](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftechnology-intro-links.webp)
[seo-dry-run-title-and-links.mp4](https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseo-dry-run-title-and-links.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e6cf88-d6db-4cfd-9895-8a9b72205420?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e6cf88-d6db-4cfd-9895-8a9b72205420&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

