### PR TITLE
seo: titles and links round 2 (2026-08-25)

### DIFF
--- a/src/config/categories.ts
+++ b/src/config/categories.ts
@@ -142,12 +142,12 @@ export const categories: Record<CategorySlug, CategoryConfig> = {
 	starships: {
 		slug: 'starships',
 		h1: 'Starships',
-		metaTitle: 'Starships',
+		metaTitle: 'NMS Starship Parts List & Wings',
 		idLabel: 'Starship Item',
 		description:
-			"A list of starship items for No Man's Sky. Our guide has everything you need to take your game to the next level.",
+			'NMS starship parts list: wings, components, and modules. Open each part page for craft costs and the recipes tied to starship management.',
 		intro:
-			'Starship items include components, modules, and parts tied to spaceflight and starship management.',
+			'Starship items include components, modules, and parts tied to spaceflight and starship management. See [technology upgrades](/technology/) and [corvette parts](/corvette/).',
 		datasets: ['Starships'],
 		idStrategy: 'props',
 	},

--- a/src/content/blog/gravitino-coil-guide-no-mans-sky.md
+++ b/src/content/blog/gravitino-coil-guide-no-mans-sky.md
@@ -1,6 +1,6 @@
 ---
-title: "No Man's Sky Gravitino Coil Guide: How to Get It and Use It"
-description: "How to unlock the Gravitino Coil in No Man's Sky, craft it, and use it for waste hauling and combat. Crafting recipe included."
+title: "NMS Gravitino Coil: Get & Use"
+description: "NMS Gravitino Coil: buy the blueprint from Eos, craft it with a Gravitino Ball plus Chromatic Metal, and use it for waste hauling and combat."
 pubDate: 2026-03-20
 updatedDate: 2026-03-20
 heroImage: "/images/blog/gravitino-coil.webp"
@@ -12,6 +12,10 @@ tags:
   - waste hauling
 featured: false
 relatedLinks:
+  - label: "Gravitino Ball"
+    href: "/curiosities/GRAVBALL/"
+  - label: "Chromatic Metal recipes"
+    href: "/raw/STELLAR2/"
   - label: "Exocraft upgrades"
     href: "/exocraft"
   - label: "Technology upgrades"

--- a/src/content/blog/no-mans-sky-fishing-guide.md
+++ b/src/content/blog/no-mans-sky-fishing-guide.md
@@ -1,6 +1,6 @@
 ---
-title: "No Man's Sky Fishing Guide: How to Fish, Best Bait, and What to Do With Your Catch"
-description: "How fishing works in No Man's Sky: getting the Fishing Rig, bait recipes, controlling fish size by depth, biomes, and what to cook or sell."
+title: "NMS Fishing Guide: Bait & Uses"
+description: "NMS fishing guide: Fishing Rig, best bait, depth for size, and what to do with fish — cook, sell, bait, or release for nanites."
 pubDate: 2024-12-20
 updatedDate: 2024-12-20
 heroImage: "/images/blog/fishing-guide.webp"
@@ -12,6 +12,8 @@ tags:
   - guide
 featured: false
 relatedLinks:
+  - label: "Chromatic Metal recipes"
+    href: "/raw/STELLAR2/"
   - label: "All fish items"
     href: "/fish"
   - label: "Rare fish"

--- a/src/content/blog/no-mans-sky-galaxies-guide.md
+++ b/src/content/blog/no-mans-sky-galaxies-guide.md
@@ -1,6 +1,6 @@
 ---
-title: "No Man's Sky Galaxies: The Complete Guide"
-description: "Everything to know about No Man's Sky galaxies. How they work, how to reach the next one, how to travel back, and which ones are worth visiting."
+title: "NMS Galaxy Types, List & Travel"
+description: "NMS galaxy types (Norm, Lush, Harsh, Empty), the 256-galaxy list, and how to travel: black holes, New Beginnings skip, and teleporting back."
 pubDate: 2026-05-03
 updatedDate: 2026-05-03
 heroImage: "/images/blog/galaxies-guide.webp"

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -31,9 +31,10 @@ import { SITE } from '@config';
 interface Props {
   item: Item;
   schemaResult: ItemPageSchemaResult;
+  relatedLinks?: Array<{ label: string; href: string }>;
 }
 
-const { item, schemaResult } = Astro.props;
+const { item, schemaResult, relatedLinks = [] } = Astro.props;
 const itemUpdateMeta = getItemUpdateMeta(item.Id);
 const normalizedSlug = (item.Slug ?? '').replace(/^\/+/, '').replace(/^cooking\//, 'food/');
 const categorySlug = normalizedSlug.split('/')[0] || 'items';
@@ -453,6 +454,17 @@ const imageBaseUrl = SITE.imageBaseUrl;
     showQuantityInput={showQuantityInput}
     imageBaseUrl={imageBaseUrl}
   />
+
+  {relatedLinks.length > 0 && (
+    <p class="mx-auto mb-4 max-w-4xl px-4 text-center text-sky-200/90">
+      {relatedLinks.map((link, index) => (
+        <>
+          {index > 0 ? ' · ' : ''}
+          <a href={link.href} class="text-cyan-300 underline hover:text-cyan-200">{link.label}</a>
+        </>
+      ))}
+    </p>
+  )}
 
   <NitroAd id="item-after-details" />
 

--- a/src/pages/[category]/[id].astro
+++ b/src/pages/[category]/[id].astro
@@ -104,7 +104,7 @@ if (!item) {
 	return Astro.redirect('/404');
 }
 
-const { title, description } = buildItemMeta(item, config.idLabel);
+const { title, description, relatedLinks } = buildItemMeta(item, config.idLabel);
 const ogImage = `${SITE.imageBaseUrl}${item.Icon}`;
 const siteOrigin = getSiteOrigin(Astro.site, Astro.url);
 const schemaResult = buildItemPageSchema({
@@ -114,5 +114,5 @@ const schemaResult = buildItemPageSchema({
 ---
 
 <Layout {title} {description} slug={config.slug} {ogImage} structuredData={schemaResult.structuredData}>
-	<Page item={item} schemaResult={schemaResult} />
+	<Page item={item} schemaResult={schemaResult} relatedLinks={relatedLinks} />
 </Layout>

--- a/src/pages/[category]/[page].astro
+++ b/src/pages/[category]/[page].astro
@@ -5,7 +5,7 @@ import Pagination from '@components/Pagination.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls, parseIntroLinks } from '@utils/seo.js';
 import type { Item } from '@utils/lookup.js';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
@@ -81,7 +81,15 @@ const { prevUrl, nextUrl } = buildPaginationUrls(siteOrigin, page);
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">{config.h1}</h1>
-	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">
+		{parseIntroLinks(intro).map((segment) =>
+			segment.href ? (
+				<a href={segment.href} class="text-cyan-300 underline hover:text-cyan-200">{segment.text}</a>
+			) : (
+				segment.text
+			)
+		)}
+	</p>
 	<div id="items" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
 		{
 			page.data.map((item, index) => (

--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '@components/Breadcrumbs.astro';
 import NitroAd from '@components/ads/NitroAd.astro';
 import { getSlug, sort } from '@utils/lookup.js';
 import { buildCollectionStructuredData, getSiteOrigin } from '@utils/structuredData.js';
-import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls } from '@utils/seo.js';
+import { buildCategoryBreadcrumbs, buildCategoryIntro, buildPaginatedMeta, buildPaginationUrls, parseIntroLinks } from '@utils/seo.js';
 import { CATEGORY_SLUGS, categories, type CategorySlug } from '../../config/categories.js';
 import { getCategoryDataset } from '../../config/categoryData.js';
 
@@ -69,7 +69,15 @@ const { nextUrl } = buildPaginationUrls(siteOrigin, page);
 >
 	<Breadcrumbs items={breadcrumbs} className="pt-4 mb-6" />
 	<h1 class="text-center text-4xl sm:text-6xl mt-12 mb-3">{config.h1}</h1>
-	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">{intro}</p>
+	<p class="mx-auto mb-12 max-w-3xl text-center text-sky-200/90">
+		{parseIntroLinks(intro).map((segment) =>
+			segment.href ? (
+				<a href={segment.href} class="text-cyan-300 underline hover:text-cyan-200">{segment.text}</a>
+			) : (
+				segment.text
+			)
+		)}
+	</p>
 	<NitroAd id="list-after-intro" />
 	<CategoryFilter type={config.slug} basePath={categoryPath} />
 </Layout>

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -21,6 +21,66 @@ const normalizePath = (path: string): string => {
 
 type ItemMetaInput = Pick<Item, 'Id' | 'Name' | 'Description' | 'Group' | 'Slug'>;
 
+export type ItemRelatedLink = {
+	label: string;
+	href: string;
+};
+
+export type IntroSegment = {
+	text: string;
+	href?: string;
+};
+
+type ItemMetaOverride = {
+	title: string;
+	description: string;
+	relatedLinks?: ItemRelatedLink[];
+};
+
+const SITE_TITLE_SUFFIX = " | No Man's Sky Recipes";
+
+const ITEM_META_OVERRIDES: Record<string, ItemMetaOverride> = {
+	PLANT_TOXIC: {
+		title: 'Fungal Mold NMS Recipe (Mould)',
+		description:
+			'Fungal Mold (Fungal Mould) NMS: harvest from fungal clusters, refine and cook it, plus the Fusion Ignitor chain that spends 600x of this crop.',
+		relatedLinks: [
+			{
+				label: 'Fusion Ignitor vs Stasis Device',
+				href: '/blog/fusion-ignitor-vs-stasis-device-no-mans-sky/',
+			},
+		],
+	},
+	TRA_ALLOY5: {
+		title: 'Superconducting Fiber NMS (Fibre)',
+		description:
+			'Superconducting Fiber (Fibre) NMS: how to get this trade good, what it sells for, and every recipe or use tied to Superconducting Fibre.',
+		relatedLinks: [{ label: 'all products', href: '/products/' }],
+	},
+};
+
+export const parseIntroLinks = (intro: string): IntroSegment[] => {
+	const segments: IntroSegment[] = [];
+	const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null = linkPattern.exec(intro);
+
+	while (match) {
+		if (match.index > lastIndex) {
+			segments.push({ text: intro.slice(lastIndex, match.index) });
+		}
+		segments.push({ text: match[1], href: match[2] });
+		lastIndex = linkPattern.lastIndex;
+		match = linkPattern.exec(intro);
+	}
+
+	if (lastIndex < intro.length) {
+		segments.push({ text: intro.slice(lastIndex) });
+	}
+
+	return segments;
+};
+
 const normalizeCategoryLabel = (value: string | undefined): string =>
 	normalizeWhitespace(value ?? '')
 		.toLowerCase()
@@ -186,7 +246,16 @@ const buildItemTitle = (item: ItemMetaInput, categoryLabel: string, uniquenessHi
 export const buildItemMeta = (
 	item: ItemMetaInput,
 	categoryLabel: string
-): { title: string; description: string } => {
+): { title: string; description: string; relatedLinks?: ItemRelatedLink[] } => {
+	const override = ITEM_META_OVERRIDES[item.Id];
+	if (override) {
+		return {
+			title: `${override.title}${SITE_TITLE_SUFFIX}`,
+			description: override.description,
+			...(override.relatedLinks ? { relatedLinks: override.relatedLinks } : {}),
+		};
+	}
+
 	const normalizedDescription = normalizeDescriptionHint(item.Description) ?? '';
 	const uniquenessHint = buildItemUniquenessHint(item, categoryLabel);
 	const title = buildItemTitle(item, categoryLabel, uniquenessHint);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Titles, metadata, and missing internal links only. No new blog posts. No body-copy rewrites except adding a missing internal link.

These six URLs are **not** in [PR 94](https://github.com/bradhave94/nms/pull/94). This branch is from `main`, not `seo/2026-08-25-dry-run`.

`/cooking` trailing-slash is still out of scope.

## Data windows

- **GSC property:** `sc-domain:nomansskyrecipes.com`
- **Current:** 2026-07-26 to 2026-08-22
- **Prior:** 2026-06-28 to 2026-07-25
- GSC positions below are from the current window unless noted as prior→current.

`GuideLayout` / `buildPaginatedMeta` / item overrides append ` | No Man's Sky Recipes` (23 chars). Title **fields** are sized so the live `<title>` lands in 50–60 characters. Item overrides do **not** re-append `| No Man's Sky Item | No Man's Sky Recipes`. `PLANT_TOXIC` and `TRA_ALLOY5` are one-off `buildItemMeta` overrides — other item pages are unchanged. `categories.ts` changes the `starships` entry only.

## Pages

### 1. `/blog/no-mans-sky-galaxies-guide/`

- **Current title:** `No Man's Sky Galaxies: The Complete Guide | No Man's Sky Recipes`
- **Proposed title:** `NMS Galaxy Types, List & Travel | No Man's Sky Recipes`
- **GSC:** 11,130 imps / 50 clicks / pos 7.83
- **Query:** `galaxy types nms` 3,099 imps / 0 clicks / pos 8.25
- Links: none added (no new body paragraph)

### 2. `/blog/no-mans-sky-fishing-guide/`

- **Current title:** `No Man's Sky Fishing Guide: How to Fish, Best Bait, and What to Do With Your Catch | No Man's Sky Recipes` (105 chars)
- **Proposed title:** `NMS Fishing Guide: Bait & Uses | No Man's Sky Recipes`
- **GSC:** 4,638 imps / 30 clicks / pos 8.20
- **Link added:** Chromatic Metal recipes → `/raw/STELLAR2/`

### 3. `/raw/PLANT_TOXIC/` (Fungal Mould)

- **Current title:** `Fungal Mould | Raw Material | No Man's Sky Recipes`
- **Proposed title:** `Fungal Mold NMS Recipe (Mould) | No Man's Sky Recipes`
- **GSC:** 1,864 imps / pos 8.21. US mold 122+99 imps vs UK mould 221
- **Link added:** Fusion Ignitor vs Stasis Device → `/blog/fusion-ignitor-vs-stasis-device-no-mans-sky/`

### 4. `/other/TRA_ALLOY5/` (Superconducting Fibre)

- **Current title:** `Superconducting Fibre | No Man's Sky Item | No Man's Sky Recipes`
- **Proposed title:** `Superconducting Fiber NMS (Fibre) | No Man's Sky Recipes`
- **GSC:** 1,054 imps / pos 10.50. US fiber cluster 90+85+68 imps, 0 clicks
- **Link added:** all products → `/products/`

### 5. `/blog/gravitino-coil-guide-no-mans-sky/`

- **Current title:** `No Man's Sky Gravitino Coil Guide: How to Get It and Use It | No Man's Sky Recipes` (82 chars, title_too_long)
- **Proposed title:** `NMS Gravitino Coil: Get & Use | No Man's Sky Recipes`
- **GSC:** 2,914 vs 3,539 imps (−625)
- **Links added:** Gravitino Ball → `/curiosities/GRAVBALL/` ; Chromatic Metal recipes → `/raw/STELLAR2/`

### 6. `/starships/`

- **Current title:** `Starships | No Man's Sky Recipes`
- **Proposed title:** `NMS Starship Parts List & Wings | No Man's Sky Recipes`
- **GSC:** 325 imps / pos 16.13
- **Intro links added:** technology upgrades → `/technology/` ; corvette parts → `/corvette/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3191478-ab1e-4a09-93fa-b72c6ff6c5ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3191478-ab1e-4a09-93fa-b72c6ff6c5ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

