### PR TITLE
Improve NitroPay fill with a desktop rail and stronger item/interstitial configs

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -167,6 +167,29 @@
     isolation: isolate;
     min-height: 100vh;
 }
+
+/* Desktop sticky right rail (Nitro `rail-right`). Left nav is 224px; only
+   viewports >= 1536px have leftover width for a 160x600 without covering
+   content. 1800px+ reserves a 300x600 gutter. Search FAB shifts with it. */
+@media (min-width: 1536px) {
+    .nitro-rail-gutter {
+        padding-right: 176px;
+    }
+
+    #open-search {
+        right: 190px;
+    }
+}
+
+@media (min-width: 1800px) {
+    .nitro-rail-gutter {
+        padding-right: 320px;
+    }
+
+    #open-search {
+        right: 334px;
+    }
+}
 .nms-bg::after {
     content: "";
     left: 0;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,7 +21,7 @@ const navigation = [
 ];
 ---
 
-<footer class="bg-black flex flex-1 flex-col lg:pl-80">
+<footer class="nitro-rail-gutter bg-black flex flex-1 flex-col lg:pl-80">
   <div class="p-6 py-12 max-w-4xl mx-auto">
     <nav class="flex flex-wrap justify-center gap-x-8 gap-y-4 sm:gap-x-12" aria-label="Footer">
       {navigation.map((item) => (

--- a/src/components/ads/NitroAd.astro
+++ b/src/components/ads/NitroAd.astro
@@ -7,6 +7,8 @@ interface Props {
 	format?: 'display' | 'article' | 'smart-flex';
 	/** Optional sizes; defaults cover common desktop + mobile IAB units. */
 	sizes?: [number, number][];
+	/** Reserved slot height in px to limit CLS. Defaults by format. */
+	minHeight?: number;
 }
 
 const {
@@ -20,7 +22,10 @@ const {
 		[320, 50],
 		[320, 100],
 	],
+	minHeight,
 } = Astro.props;
+
+const reservedHeight = minHeight ?? (format === 'smart-flex' ? 250 : 90);
 
 const options = {
 	...(format !== 'display' ? { format } : {}),
@@ -40,13 +45,18 @@ const options = {
 const scriptBody = `window.nitroAds.createAd(${JSON.stringify(id)}, ${JSON.stringify(options)});`;
 ---
 
-<div
-	id={id}
-	class:list={[
-		'nitro-ad mx-auto my-8 flex w-full max-w-[970px] items-center justify-center',
-		format === 'smart-flex' ? 'min-h-[250px]' : 'min-h-[90px]',
-		className,
-	]}
-	aria-hidden="true"
-></div>
+<section
+	class:list={['nitro-ad-slot mx-auto my-8 w-full max-w-[970px]', className]}
+	aria-label="Advertisement"
+>
+	<p class="nitro-ad-label mb-1 text-center text-[10px] font-medium uppercase tracking-[0.2em] text-gray-400">
+		Advertisement
+	</p>
+	<div
+		id={id}
+		class="nitro-ad flex w-full items-center justify-center"
+		style={`min-height: ${reservedHeight}px`}
+	>
+	</div>
+</section>
 <script is:inline set:html={scriptBody} />

--- a/src/components/ads/NitroGlobalAds.astro
+++ b/src/components/ads/NitroGlobalAds.astro
@@ -1,8 +1,17 @@
 ---
 /**
  * Sitewide NitroPay formats that do not need a placeholder div.
+ *
  * Floating video is available in the API (`format: "floating"`) but is not
  * enabled for this site in the Placement Builder yet — add when Nitro unlocks it.
+ *
+ * Sticky side rail: only the right rail is mounted. The left 224px is the
+ * desktop nav (`#desktop-sidebar`), so a left rail would cover navigation.
+ * The right gutter is reserved in CSS (`.nitro-rail-gutter`) from 1536px up.
+ *
+ * If `rail-right` does not fill after deploy, confirm the rail format is
+ * unlocked in Nitro Placement Builder and debug collisions with
+ * `?nitroads_debug=1`.
  */
 ---
 
@@ -22,9 +31,51 @@
 		},
 	});
 
+	// Interstitial is a navigate/unhide vignette — fill is inherently lower
+	// than display. The previous `(min-width: 768px)` query skipped phones,
+	// where this site's Nitro Pixel CPM ($0.56) and fill (79.6%) beat desktop
+	// ($0.29 / 70%). Official trigger: show again when the tab is unhidden.
 	window.nitroAds.createAd('interstitial', {
 		format: 'interstitial',
-		mediaQuery: '(min-width: 768px)',
+		interstitial: {
+			triggers: {
+				unhideWindow: true,
+			},
+		},
+		report: {
+			enabled: true,
+			icon: true,
+			wording: 'Report Ad',
+			position: 'top-right',
+		},
+	});
+
+	window.nitroAds.createAd('rail-right', {
+		format: 'rail',
+		rail: 'right',
+		railDistance: 0,
+		railOffsetTop: 16,
+		railOffsetBottom: 120,
+		railSpacing: 10,
+		railVerticalAlign: 'center',
+		railCollisionWhitelist: [
+			'#desktop-sidebar',
+			'#mobile-sidebar',
+			'#calculators-flyout',
+			'#catalogs-flyout',
+			'#open-search',
+			'#site-search',
+			'#guide-sidebar',
+			'footer',
+		],
+		mediaQuery: '(min-width: 1536px)',
+		sizes: [
+			[160, 600],
+			[300, 600],
+			[320, 480],
+			[300, 250],
+		],
+		refreshTime: 30,
 		report: {
 			enabled: true,
 			icon: true,

--- a/src/layouts/GuideLayout.astro
+++ b/src/layouts/GuideLayout.astro
@@ -166,6 +166,7 @@ const modifiedTime = (guide.data.updatedDate ?? guide.data.pubDate).toISOString(
 				<NitroAd
 					id="guide-sidebar"
 					class="my-0 max-w-[300px]"
+					minHeight={250}
 					sizes={[[300, 250]]}
 				/>
 				{tocHeadings.length > 0 && (

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -480,7 +480,17 @@ const imageBaseUrl = SITE.imageBaseUrl;
     </p>
   )}
 
-  <NitroAd id="item-after-details" />
+  <NitroAd
+    id="item-after-details"
+    minHeight={280}
+    sizes={[
+      [300, 250],
+      [336, 280],
+      [728, 90],
+      [320, 100],
+      [320, 50],
+    ]}
+  />
 
   <CraftingSection
     item={item}

--- a/src/layouts/Sidebar.astro
+++ b/src/layouts/Sidebar.astro
@@ -502,7 +502,7 @@ const sectionLabelClasses =
 	</div>
 
 	<!-- Desktop sidebar -->
-	<div class="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-56 lg:flex-col">
+	<div id="desktop-sidebar" class="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-56 lg:flex-col">
 		<div class="flex min-h-0 flex-1 flex-col bg-black">
 			<div class="flex flex-1 flex-col overflow-y-auto overflow-x-hidden hide-scrollbar pt-3 pb-3">
 				<a href="/" class="mb-3 block w-full px-3">
@@ -697,7 +697,7 @@ const sectionLabelClasses =
 		</div>
 	</div>
 
-	<div class="flex flex-1 flex-col lg:pl-56">
+	<div class="nitro-rail-gutter flex flex-1 flex-col lg:pl-56">
 		<div class="sticky top-0 z-10 bg-black p-3 text-right lg:hidden">
 			<button
 				id="sidebar-open"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Code-side NitroPay changes for publisher site 2507. `vercel.json` still 301s `/ads.txt` → `https://api.nitropay.com/v1/ads-2507.txt` (no second ads.txt). `anchor-bottom` is unchanged.

## Revenue levers (last 30 days, Nitro Pixel gross)

| Change | Lever | Why |
|---|---|---|
| New `rail-right` sticky rail (desktop ≥1536px) | Missing inventory / weak desktop CPM ($0.29 vs phone $0.56) | No side rail existed. Left 224px is nav, so only a **right** rail is mounted. Standard skyscraper sizes (160×600, 300×600, 320×480, 300×250) plus a reserved gutter so the rail does not cover content, nav, or the search FAB. |
| `item-after-details` sizes + 280px reserved height + ad label | Weakest in-content unit ($27.46, **$0.28 CPM**, 68.3% fill, 46k unfilled) | Slot reserved 90px while bidding 300×250 (CLS + cheap leaderboard fill). Now prefers 300×250 / 336×280, keeps 728×90 and mobile 320s for fill, drops 970×90 (often does not fit the item column). Position unchanged (after details, before recipes). |
| Interstitial: drop `(min-width: 768px)`, add `unhideWindow` | **$0.49 CPM** but only **27.3% fill** / 22k unfilled | Desktop-only query skipped phones (higher site CPM and fill). Nitro interstitials are navigate/unhide vignettes; the official `unhideWindow` trigger was missing. No panel-only settings invented. |
| Keep `anchor-bottom` | **$123.12**, 72.8% fill — biggest earner | Config untouched. Rail `railOffsetBottom: 120` keeps the skyscraper above the anchor. |
| Ad labels on display slots | Policy / viewability hygiene | “Advertisement” label on `NitroAd` placeholders. |

`table-above` ($53.92, 79.4% fill) is unchanged.

## Layout notes

- Right gutter: 176px from 1536px, 320px from 1800px (`.nitro-rail-gutter` on the main column and footer).
- Search FAB shifts with the gutter so it does not sit under the rail.
- `railCollisionWhitelist` includes nav, flyouts, search, guide sidebar, and footer. Debug leftover collisions with `?nitroads_debug=1`.

## Nitro panel follow-ups (cannot do from this repo)

- Confirm **rail / sticky side rail** is unlocked in Placement Builder for site 2507. If `rail-right` reports 0 impressions, the format likely still needs to be enabled.
- Floating video remains commented as locked (`format: "floating"`).
- Interstitial frequency / demand caps in the panel can still limit fill after this code fix.
- Optional Victory Wrap / dual-rail premium if Nitro later qualifies the site (left rail is blocked by nav today).

## Verification

- `pnpm run type-check`, `pnpm run lint`, and `pnpm run build` passed.
- Production `/ads.txt` still redirects to `https://api.nitropay.com/v1/ads-2507.txt`.
- Built HTML includes `rail-right`, ungated interstitial + `unhideWindow`, 280px `item-after-details`, and Advertisement labels.
- Headless screenshots: 1280px has no rail gutter; 1600px reserves ~176px; 1800px reserves ~320px. Search FAB shifts with the gutter. Left nav stays clear.
- Live Nitro creatives did not fill in this environment (expected).

[Item page at 1600px with reserved right rail gutter](https://cursor.com/agents/bc-c149c28d-7386-444a-860b-5dd2ef268521/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fitem_page_1600_rail_gutter.png)
[Item page at 1800px with wider 300x600 gutter](https://cursor.com/agents/bc-c149c28d-7386-444a-860b-5dd2ef268521/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fitem_page_1800_wide_rail_gutter.png)
[Item-after-details Advertisement slot before refining](https://cursor.com/agents/bc-c149c28d-7386-444a-860b-5dd2ef268521/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fitem_after_details_advertisement_slot.webp)
[nitropay_ad_layout_walkthrough.mp4](https://cursor.com/agents/bc-c149c28d-7386-444a-860b-5dd2ef268521/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnitropay_ad_layout_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c149c28d-7386-444a-860b-5dd2ef268521?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c149c28d-7386-444a-860b-5dd2ef268521&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

